### PR TITLE
eth/ethconfig: Update 'TxLookupLimit' default value.

### DIFF
--- a/eth/ethconfig/config.go
+++ b/eth/ethconfig/config.go
@@ -73,7 +73,7 @@ var Defaults = Config{
 		DatasetsLockMmap: false,
 	},
 	NetworkId:               1111,
-	TxLookupLimit:           2350000,
+	TxLookupLimit:           31536000,
 	LightPeers:              100,
 	UltraLightFraction:      75,
 	DatabaseCache:           512,


### PR DESCRIPTION
Update 'TxLookupLimit' default value to match the block time of Wemix Chain. (about one year, 31536000)