### PR TITLE
internal/ethapi: changed 'blockNumber' data type (GetReceiptsByHash RPC)

### DIFF
--- a/internal/ethapi/api.go
+++ b/internal/ethapi/api.go
@@ -730,7 +730,7 @@ func (s *PublicBlockChainAPI) GetReceiptsByHash(ctx context.Context, blockHash c
 
 		fields := map[string]interface{}{
 			"blockHash":         blockHash,
-			"blockNumber":       bigblock,
+			"blockNumber":       hexutil.Uint64(block.NumberU64()),
 			"transactionHash":   receipt.TxHash,
 			"transactionIndex":  hexutil.Uint64(index),
 			"from":              from,


### PR DESCRIPTION
internal/ethapi: changed 'blockNumber' data type from BigInt to hexUtil.Uint64 (GetReceiptsByHash RPC)