### PR TITLE
ci: add ci for devnet

### DIFF
--- a/.github/workflows/devnet-ci.yml
+++ b/.github/workflows/devnet-ci.yml
@@ -1,0 +1,60 @@
+name: devnet-ci
+
+on:
+  pull_request:
+    branches:
+      - devnet
+
+jobs:
+  build_test:
+    runs-on: ubuntu-20.04
+    steps:
+    - uses: actions/checkout@v3
+      with:
+        ref: ${{ github.event.pull_request.head.sha }}
+
+    - name: Set up Go
+      uses: actions/setup-go@v3
+      with:
+        go-version: 1.19
+      
+    - name: Build Go-WEMIX
+      run: make gwemix.tar.gz
+    - name: Check Build
+      run: ls -al build/gwemix.tar.gz
+
+  lint_test:
+    strategy:
+      fail-fast: false
+      matrix:
+        version: [1.17, 1.18, 1.19]
+    runs-on: ubuntu-20.04
+    steps:
+    - uses: actions/checkout@v3
+      with:
+        ref: ${{ github.event.pull_request.head.sha }}
+
+    - name: Set up Go
+      uses: actions/setup-go@v3
+      with:
+        go-version: ${{ matrix.version }}
+      
+    - name: Check Lint
+      run: make lint
+
+  unit_test:
+    runs-on: ubuntu-20.04
+    steps:
+    - uses: actions/checkout@v3
+      with:
+        ref: ${{ github.event.pull_request.head.sha }}
+
+    - name: Set up Go
+      uses: actions/setup-go@v3
+      with:
+        go-version: 1.19
+
+    - name: Check golang Test Cases 
+      run: |
+        unset ANDROID_HOME
+        make test


### PR DESCRIPTION
I'll create 3 PRs on `devnet`

- [x] 1. this one; add ci for devnet (same with master.ci; run long time test)
- [ ] 2. merge PR; dev -> devnet (including brioche feature. v0.10.8): this needs ci working for merge
- [ ] 3. add devnet-only feature; devnet hard fork configuration