### PR TITLE
Make artifact for devnet

### DIFF
--- a/.github/workflows/devnet-ci.yml
+++ b/.github/workflows/devnet-ci.yml
@@ -27,13 +27,13 @@ jobs:
         tar tf build/gwemix.tar.gz
 
     - name: Move results to artifact
-      run: mv build/gwemix.tar.gz gwemix-${{ github.event.pull_request.head.sha }}-linux-rocksdb.tar.gz
+      run: mv build/gwemix.tar.gz gwemix-${{ github.event.pull_request.head.sha }}-linux-amd64-rocksdb.tar.gz
 
     - name: Upload Go-WEMIX
       uses: actions/upload-artifact@v4
       with:
         name: artifact-${{ github.event.pull_request.head.sha }}
-        path: gwemix-${{ github.event.pull_request.head.sha }}-linux-rocksdb.tar.gz
+        path: gwemix-${{ github.event.pull_request.head.sha }}-linux-amd64-rocksdb.tar.gz
         retention-days: 7
 
   lint_test:

--- a/.github/workflows/devnet-ci.yml
+++ b/.github/workflows/devnet-ci.yml
@@ -19,9 +19,22 @@ jobs:
         go-version: 1.19
       
     - name: Build Go-WEMIX
-      run: make gwemix.tar.gz
-    - name: Check Build
-      run: ls -al build/gwemix.tar.gz
+      run: USE_ROCKSDB=YES make gwemix.tar.gz
+
+    - name: Stat Go-WEMIX
+      run: |
+        ls -l build/gwemix.tar.gz
+        tar tf build/gwemix.tar.gz
+
+    - name: Move results to artifact
+      run: mv build/gwemix.tar.gz gwemix-${{ github.event.pull_request.head.sha }}-linux-rocksdb.tar.gz
+
+    - name: Upload Go-WEMIX
+      uses: actions/upload-artifact@v4
+      with:
+        name: artifact-${{ github.event.pull_request.head.sha }}
+        path: gwemix-${{ github.event.pull_request.head.sha }}-linux-rocksdb.tar.gz
+        retention-days: 7
 
   lint_test:
     strategy:


### PR DESCRIPTION
Make artifact.zip file containing gwemix binary running on devnet.
The artifact can be found on workflow in Actions tab.

Artifact files can be downloaded by any github account who can access to repo.