### PR TITLE
Add release ci

### DIFF
--- a/.github/workflows/artifacts.yml
+++ b/.github/workflows/artifacts.yml
@@ -9,7 +9,7 @@ on:
 jobs:
 
   build:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
     steps:
     - uses: actions/checkout@v4
 

--- a/.github/workflows/artifacts.yml
+++ b/.github/workflows/artifacts.yml
@@ -18,6 +18,11 @@ jobs:
       with:
         go-version: '1.19'
 
+    - name: Setup packages
+      run: |
+        sudo apt install -y libjemalloc-dev liblz4-dev libsnappy-dev libzstd-dev libudev-dev
+        sudo apt remove -y bzip2 libbz2-dev zlib1g-dev
+
     - name: Build Go-WEMIX tarball
       run: USE_ROCKSDB=YES make gwemix.tar.gz
 

--- a/.github/workflows/artifacts.yml
+++ b/.github/workflows/artifacts.yml
@@ -26,16 +26,22 @@ jobs:
     - name: Build Go-WEMIX tarball
       run: USE_ROCKSDB=YES make gwemix.tar.gz
 
-    - name: Stat Go-WEMIX tarball
+    - name: Set version
       run: |
-        ls -l build/gwemix.tar.gz
-        tar tf build/gwemix.tar.gz
+        GWEMIX_VERSION_META="v$(build/bin/gwemix version | awk '/^Version/{ print $2 }')"
+        echo "GWEMIX_VERSION_META=$GWEMIX_VERSION_META" >> "$GITHUB_ENV"
+        echo "GWEMIX_VERSION=$(echo $GWEMIX_VERSION_META | cut -d'-' -f1)" >> "$GITHUB_ENV"
+        echo "GWEMIX_META=$(echo $GWEMIX_VERSION_META | cut -d'-' -f2-)" >> "$GITHUB_ENV"
+        echo "GWEMIX_COMMITHASH=$(echo ${{ github.sha }} | cut -c1-8)" >> "$GITHUB_ENV"
+
+    - name: Display ELF info
+      run: readelf -dV build/bin/gwemix
 
     - name: Move results to artifact
-      run: mv build/gwemix.tar.gz gwemix-${{ github.ref_name }}-${{ github.sha }}-linux-amd64-rocksdb.tar.gz
+      run: mv build/gwemix.tar.gz gwemix-${{ env.GWEMIX_VERSION_META }}-${{ env.GWEMIX_COMMITHASH }}-linux-amd64-rocksdb.tar.gz
 
     - name: Upload Go-WEMIX
       uses: actions/upload-artifact@v4
       with:
-        name: artifact-${{ github.ref_name }}-${{ github.sha }}
-        path: gwemix-${{ github.ref_name }}-${{ github.sha }}-linux-amd64-rocksdb.tar.gz
+        name: artifact-${{ env.GWEMIX_VERSION_META }}-${{ env.GWEMIX_COMMITHASH }}
+        path: gwemix-${{ env.GWEMIX_VERSION_META }}-${{ env.GWEMIX_COMMITHASH }}-linux-amd64-rocksdb.tar.gz

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -8,7 +8,7 @@ on:
 jobs:
 
   build:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
     steps:
     - uses: actions/checkout@v4
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -17,14 +17,25 @@ jobs:
       with:
         go-version: '1.19'
 
+    - name: Setup packages
+      run: |
+        sudo apt install -y libjemalloc-dev liblz4-dev libsnappy-dev libzstd-dev libudev-dev
+        sudo apt remove -y bzip2 libbz2-dev zlib1g-dev
+
     - name: Build Go-WEMIX tarball (rocksdb)
       run: USE_ROCKSDB=YES make gwemix.tar.gz
+
+    - name: Display ELF info (rocksdb)
+      run: readelf -dV build/bin/gwemix
 
     - name: Move results to artifact (rocksdb)
       run: mv build/gwemix.tar.gz gwemix-${{ github.ref_name }}-linux-amd64-rocksdb.tar.gz
 
     - name: Build Go-WEMIX tarball (leveldb)
       run: USE_ROCKSDB=NO make gwemix.tar.gz
+
+    - name: Display ELF info (leveldb)
+      run: readelf -dV build/bin/gwemix
 
     - name: Move results to artifact (leveldb)
       run: mv build/gwemix.tar.gz gwemix-${{ github.ref_name }}-linux-amd64-leveldb.tar.gz
@@ -34,7 +45,6 @@ jobs:
       with:
         name: WEMIX3.0 Mainnet and Testnet Build (${{ github.ref_name }})
         draft: true
-        prerelease: true
         files: |
           gwemix-${{ github.ref_name }}-linux-amd64-rocksdb.tar.gz
           gwemix-${{ github.ref_name }}-linux-amd64-leveldb.tar.gz

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -21,20 +21,20 @@ jobs:
       run: USE_ROCKSDB=YES make gwemix.tar.gz
 
     - name: Move results to artifact (rocksdb)
-      run: mv build/gwemix.tar.gz gwemix-${{ github.ref_name }}-${{ github.sha }}-linux-amd64-rocksdb.tar.gz
+      run: mv build/gwemix.tar.gz gwemix-${{ github.ref_name }}-linux-amd64-rocksdb.tar.gz
 
     - name: Build Go-WEMIX tarball (leveldb)
       run: USE_ROCKSDB=NO make gwemix.tar.gz
 
     - name: Move results to artifact (leveldb)
-      run: mv build/gwemix.tar.gz gwemix-${{ github.ref_name }}-${{ github.sha }}-linux-amd64-leveldb.tar.gz
+      run: mv build/gwemix.tar.gz gwemix-${{ github.ref_name }}-linux-amd64-leveldb.tar.gz
 
     - name: GH Release
       uses: softprops/action-gh-release@v2.0.5
       with:
-        name: WEMIX3.0 Mainnet and Testnet Build (${{ github.sha }})
+        name: WEMIX3.0 Mainnet and Testnet Build (${{ github.ref_name }})
         draft: true
         prerelease: true
         files: |
-          gwemix-${{ github.ref_name }}-${{ github.sha }}-linux-amd64-rocksdb.tar.gz
-          gwemix-${{ github.ref_name }}-${{ github.sha }}-linux-amd64-leveldb.tar.gz
+          gwemix-${{ github.ref_name }}-linux-amd64-rocksdb.tar.gz
+          gwemix-${{ github.ref_name }}-linux-amd64-leveldb.tar.gz

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,40 @@
+name: "Release a tag as draft"
+
+on:
+  push:
+    tags:
+      - w*
+
+jobs:
+
+  build:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v4
+
+    - name: Set up Go
+      uses: actions/setup-go@v4
+      with:
+        go-version: '1.19'
+
+    - name: Build Go-WEMIX tarball (rocksdb)
+      run: USE_ROCKSDB=YES make gwemix.tar.gz
+
+    - name: Move results to artifact (rocksdb)
+      run: mv build/gwemix.tar.gz gwemix-${{ github.ref_name }}-${{ github.sha }}-linux-amd64-rocksdb.tar.gz
+
+    - name: Build Go-WEMIX tarball (leveldb)
+      run: USE_ROCKSDB=NO make gwemix.tar.gz
+
+    - name: Move results to artifact (leveldb)
+      run: mv build/gwemix.tar.gz gwemix-${{ github.ref_name }}-${{ github.sha }}-linux-amd64-leveldb.tar.gz
+
+    - name: GH Release
+      uses: softprops/action-gh-release@v2.0.5
+      with:
+        name: WEMIX3.0 Mainnet and Testnet Build (${{ github.sha }})
+        draft: true
+        prerelease: true
+        files: |
+          gwemix-${{ github.ref_name }}-${{ github.sha }}-linux-amd64-rocksdb.tar.gz
+          gwemix-${{ github.ref_name }}-${{ github.sha }}-linux-amd64-level.tar.gz

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -37,4 +37,4 @@ jobs:
         prerelease: true
         files: |
           gwemix-${{ github.ref_name }}-${{ github.sha }}-linux-amd64-rocksdb.tar.gz
-          gwemix-${{ github.ref_name }}-${{ github.sha }}-linux-amd64-level.tar.gz
+          gwemix-${{ github.ref_name }}-${{ github.sha }}-linux-amd64-leveldb.tar.gz

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -25,11 +25,19 @@ jobs:
     - name: Build Go-WEMIX tarball (rocksdb)
       run: USE_ROCKSDB=YES make gwemix.tar.gz
 
+    - name: Set version
+      run: |
+        GWEMIX_VERSION_META="v$(build/bin/gwemix version | awk '/^Version/{ print $2 }')"
+        echo "GWEMIX_VERSION_META=$GWEMIX_VERSION_META" >> "$GITHUB_ENV"
+        echo "GWEMIX_VERSION=$(echo $GWEMIX_VERSION_META | cut -d'-' -f1)" >> "$GITHUB_ENV"
+        echo "GWEMIX_META=$(echo $GWEMIX_VERSION_META | cut -d'-' -f2-)" >> "$GITHUB_ENV"
+        echo "GWEMIX_COMMITHASH=$(echo ${{ github.sha }} | cut -c1-8)" >> "$GITHUB_ENV"
+
     - name: Display ELF info (rocksdb)
       run: readelf -dV build/bin/gwemix
 
     - name: Move results to artifact (rocksdb)
-      run: mv build/gwemix.tar.gz gwemix-${{ github.ref_name }}-${{ github.sha }}-linux-amd64-rocksdb.tar.gz
+      run: mv build/gwemix.tar.gz gwemix-${{ env.GWEMIX_VERSION_META }}-${{ env.GWEMIX_COMMITHASH }}-linux-amd64-rocksdb.tar.gz
 
     - name: Build Go-WEMIX tarball (leveldb)
       run: USE_ROCKSDB=NO make gwemix.tar.gz
@@ -38,13 +46,13 @@ jobs:
       run: readelf -dV build/bin/gwemix
 
     - name: Move results to artifact (leveldb)
-      run: mv build/gwemix.tar.gz gwemix-${{ github.ref_name }}-${{ github.sha }}-linux-amd64-leveldb.tar.gz
+      run: mv build/gwemix.tar.gz gwemix-${{ env.GWEMIX_VERSION_META }}-${{ env.GWEMIX_COMMITHASH }}-linux-amd64-leveldb.tar.gz
 
     - name: GH Release
       uses: softprops/action-gh-release@v2.0.5
       with:
-        name: WEMIX3.0 Mainnet and Testnet Build (${{ github.ref_name }})
+        name: WEMIX3.0 Mainnet and Testnet Build (${{ env.GWEMIX_VERSION }})
         draft: true
         files: |
-          gwemix-${{ github.ref_name }}-${{ github.sha }}-linux-amd64-rocksdb.tar.gz
-          gwemix-${{ github.ref_name }}-${{ github.sha }}-linux-amd64-leveldb.tar.gz
+          gwemix-${{ env.GWEMIX_VERSION_META }}-${{ env.GWEMIX_COMMITHASH }}-linux-amd64-rocksdb.tar.gz
+          gwemix-${{ env.GWEMIX_VERSION_META }}-${{ env.GWEMIX_COMMITHASH }}-linux-amd64-leveldb.tar.gz

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -29,7 +29,7 @@ jobs:
       run: readelf -dV build/bin/gwemix
 
     - name: Move results to artifact (rocksdb)
-      run: mv build/gwemix.tar.gz gwemix-${{ github.ref_name }}-linux-amd64-rocksdb.tar.gz
+      run: mv build/gwemix.tar.gz gwemix-${{ github.ref_name }}-${{ github.sha }}-linux-amd64-rocksdb.tar.gz
 
     - name: Build Go-WEMIX tarball (leveldb)
       run: USE_ROCKSDB=NO make gwemix.tar.gz
@@ -38,7 +38,7 @@ jobs:
       run: readelf -dV build/bin/gwemix
 
     - name: Move results to artifact (leveldb)
-      run: mv build/gwemix.tar.gz gwemix-${{ github.ref_name }}-linux-amd64-leveldb.tar.gz
+      run: mv build/gwemix.tar.gz gwemix-${{ github.ref_name }}-${{ github.sha }}-linux-amd64-leveldb.tar.gz
 
     - name: GH Release
       uses: softprops/action-gh-release@v2.0.5
@@ -46,5 +46,5 @@ jobs:
         name: WEMIX3.0 Mainnet and Testnet Build (${{ github.ref_name }})
         draft: true
         files: |
-          gwemix-${{ github.ref_name }}-linux-amd64-rocksdb.tar.gz
-          gwemix-${{ github.ref_name }}-linux-amd64-leveldb.tar.gz
+          gwemix-${{ github.ref_name }}-${{ github.sha }}-linux-amd64-rocksdb.tar.gz
+          gwemix-${{ github.ref_name }}-${{ github.sha }}-linux-amd64-leveldb.tar.gz


### PR DESCRIPTION
This PR makes release by using Github Actions whenever tag starting with `w` pushed.
The generated release is draft so it is invisible by default.
It can be published after completing description manually.
As previous releases, the generated release contain source code (zip, tar.gz) together with gwemix binaries both for rocksdb (legacy) and leveldb versions.