### PR TITLE
Feat/update snapshot pending state

### DIFF
--- a/ethclient/gethclient/gethclient_test.go
+++ b/ethclient/gethclient/gethclient_test.go
@@ -147,7 +147,7 @@ func testAccessList(t *testing.T, client *rpc.Client) {
 		From:     testAddr,
 		To:       &common.Address{},
 		Gas:      21000,
-		GasPrice: big.NewInt(765625000),
+		GasPrice: big.NewInt(875000000),
 		Value:    big.NewInt(1),
 	}
 	al, gas, vmErr, err := ec.CreateAccessList(context.Background(), msg)

--- a/graphql/graphql.go
+++ b/graphql/graphql.go
@@ -1130,7 +1130,7 @@ func (p *Pending) Call(ctx context.Context, args struct {
 func (p *Pending) EstimateGas(ctx context.Context, args struct {
 	Data ethapi.TransactionArgs
 }) (Long, error) {
-	pendingBlockNr := rpc.BlockNumberOrHashWithNumber(rpc.PendingBlockNumber)
+	pendingBlockNr := rpc.BlockNumberOrHashWithNumber(rpc.LatestBlockNumber)
 	gas, err := ethapi.DoEstimateGas(ctx, p.backend, args.Data, pendingBlockNr, p.backend.RPCGasCap())
 	return Long(gas), err
 }

--- a/graphql/graphql.go
+++ b/graphql/graphql.go
@@ -1130,7 +1130,7 @@ func (p *Pending) Call(ctx context.Context, args struct {
 func (p *Pending) EstimateGas(ctx context.Context, args struct {
 	Data ethapi.TransactionArgs
 }) (Long, error) {
-	pendingBlockNr := rpc.BlockNumberOrHashWithNumber(rpc.LatestBlockNumber)
+	pendingBlockNr := rpc.BlockNumberOrHashWithNumber(rpc.PendingBlockNumber)
 	gas, err := ethapi.DoEstimateGas(ctx, p.backend, args.Data, pendingBlockNr, p.backend.RPCGasCap())
 	return Long(gas), err
 }

--- a/internal/ethapi/api.go
+++ b/internal/ethapi/api.go
@@ -1338,7 +1338,7 @@ func DoEstimateGas(ctx context.Context, b Backend, args TransactionArgs, blockNr
 // EstimateGas returns an estimate of the amount of gas needed to execute the
 // given transaction against the current pending block.
 func (s *PublicBlockChainAPI) EstimateGas(ctx context.Context, args TransactionArgs, blockNrOrHash *rpc.BlockNumberOrHash) (hexutil.Uint64, error) {
-	bNrOrHash := rpc.BlockNumberOrHashWithNumber(rpc.PendingBlockNumber)
+	bNrOrHash := rpc.BlockNumberOrHashWithNumber(rpc.LatestBlockNumber)
 	if blockNrOrHash != nil {
 		bNrOrHash = *blockNrOrHash
 	}
@@ -1622,7 +1622,7 @@ type accessListResult struct {
 // CreateAccessList creates a EIP-2930 type AccessList for the given transaction.
 // Reexec and BlockNrOrHash can be specified to create the accessList on top of a certain state.
 func (s *PublicBlockChainAPI) CreateAccessList(ctx context.Context, args TransactionArgs, blockNrOrHash *rpc.BlockNumberOrHash) (*accessListResult, error) {
-	bNrOrHash := rpc.BlockNumberOrHashWithNumber(rpc.PendingBlockNumber)
+	bNrOrHash := rpc.BlockNumberOrHashWithNumber(rpc.LatestBlockNumber)
 	if blockNrOrHash != nil {
 		bNrOrHash = *blockNrOrHash
 	}

--- a/miner/worker.go
+++ b/miner/worker.go
@@ -599,8 +599,10 @@ func (w *worker) mainLoop() {
 			// In wemix, costly interrupt / resubmit is disabled
 			if wemixminer.IsPoW() {
 				w.commitWork(req.interrupt, req.noempty, req.timestamp)
-			} else {
+			} else if wemixminer.AmPartner() {
 				w.commitWork(nil, req.noempty, req.timestamp)
+			} else {
+				w.refreshPending(true)
 			}
 
 		case req := <-w.getWorkCh:

--- a/miner/worker.go
+++ b/miner/worker.go
@@ -119,6 +119,7 @@ func (env *environment) copy() *environment {
 		coinbase:  env.coinbase,
 		header:    types.CopyHeader(env.header),
 		receipts:  copyReceipts(env.receipts),
+		till:      env.till,
 	}
 	if env.gasPool != nil {
 		gasPool := *env.gasPool
@@ -1268,8 +1269,6 @@ func (w *worker) commitTransactionsEx(env *environment, interrupt *int32, tstart
 
 	}
 
-	time.Sleep(time.Until(*env.till))
-
 	log.Debug("Block", "number", env.header.Number.Int64(), "elapsed", common.PrettyDuration(time.Since(tstart)), "txs", len(committedTxs))
 
 	return false
@@ -1769,6 +1768,12 @@ func (w *worker) commitEx(env *environment, interval func(), update bool, start 
 					}
 					logs = append(logs, receipt.Logs...)
 				}
+
+				if update {
+					w.updateSnapshot(env)
+				}
+				time.Sleep(time.Until(*env.till))
+
 				if !wemixminer.IsPoW() {
 					if err = wemixminer.ReleaseMiningToken(sealedBlock.Number(), sealedBlock.Hash(), sealedBlock.ParentHash()); err != nil {
 						return err


### PR DESCRIPTION
pr is for issue[#109](https://github.com/wemixarchive/go-wemix/issues/109)

the issue was about `estimateGas` function fails when it 'call' contract to simulate tx data in below condition : 
1. estimateGas function is sent to mining node
2. tx data executed by estimate Gas needs latest block state(the current block state) to success
3. mining node gets mining token at the time when tx requests estimateGas

it is due to 2 factors : 
1. estimateGas use `PendingBlock` to estimate gas of tx and it refers to snapshot db
2.  when mining node acquire mining token snapshot update is delayed due to blockCreationTime. ( thus the case is more frequent when blockCreationTime is long)

so the work is done as below :
1. fix estimateGas function to use `LatestBlock` instead of PendingBlock
2. however, it is logical for mining node to update pending state properly, updateSnapshot **before** time.Sleep
3. additionally, non-mining node is entering commitWork which is useless; just updateSnapshot if the node is not miner member 




