### PR TITLE
fix : call staker address

### DIFF
--- a/wemix/admin.go
+++ b/wemix/admin.go
@@ -342,9 +342,9 @@ func (ma *wemixAdmin) getRewardParams(ctx context.Context, height *big.Int) (*re
 	}
 	rp.distributionMethod = []*big.Int{distributionMethod1, distributionMethod2, distributionMethod3, distributionMethod4}
 
-	staker, err := contracts.Registry.GetContractAddress(opts, metclient.ToBytes32(gov.DOMAIN_Staking))
+	staker, err := contracts.Registry.GetContractAddress(opts, metclient.ToBytes32(gov.DOMAIN_StakingReward))
 	if err != nil {
-		return nil, errors.Wrap(err, gov.DOMAIN_Staking)
+		return nil, errors.Wrap(err, gov.DOMAIN_StakingReward)
 	}
 	rp.staker = &staker
 


### PR DESCRIPTION
I have made a modification because "Staking" was being called instead of "StakingRewarder" at the appropriate point.


(Egon) adding more explanation:
Due to this bug, the following error occurred when attaching an 'EN' to devnet during block sync. The cause was an incorrect address for `StakingReward`, which resulted in incorrect reward distribution, leading to block verification failure.

```
WARN [07-18|17:09:02.634] Failed to load old bad blocks            error="leveldb: not found"
ERROR[07-18|17:09:02.634] 
########## BAD BLOCK #########
Chain config: {ChainID: 1113 Homestead: 0 DAO: 0 DAOSupport: true EIP150: 0 EIP155: 0 EIP158: 0 Byzantium: 0 Constantinople: 0 Petersburg: 0 Istanbul: 0, Muir Glacier: 0, Berlin: 0, London: 0, Arrow Glacier: <nil>, MergeFork: <nil>, PangyoFork: 0, ApplepieFork: 0, BriocheFork: 607147, Terminal TD: <nil>, BriocheConfig: {BlockReward: 1000000000000000000 FirstHalvingBlock: 607147 HalvingPeriod: 63115200 FinishRewardBlock: 2412358747 HalvingTimes: 16 HalvingRate: 50}, Engine: ethash}

Number: 34
Hash: 0xc23e8d6534221e798f0aa7c8a08b10f9409c4af1a719eac9c076e2727a93d6d8
	 0: cumulative: 98277 gas: 98277 contract: 0x0000000000000000000000000000000000000000 status: 1 tx: 0x275d3945ba0c91275ca77a5ba9201b6f1bbcc23814dd83998b0aa065d059b68a logs: [0x140046440b0 0x14004644160 0x14004644210] bloom: 00000000000000000000000000000000000000000000000200800040000000000000000000000000000000000800000000000000000000000000080000000000000000000000000000000000000200000001000000000000000000000000000000000400020000000000000000000840000000000020000000000000000000400000000000000000000400000000000000000000000080000000000000000000000000400001000000000000000400000000000000000000000800000000000000000000000000000000000000040000000000000000000000000000000020000000000000000000000000000000000000000000000000000000000000000000 state: 


Error: remote block hash is different from being processed one locally (remote=0xc23e8d6534221e798f0aa7c8a08b10f9409c4af1a719eac9c076e2727a93d6d8, local=0x5046a9ee7ae0c431a652dac7d84442730ca07cf72faecc11a87783bca669502a)
##############################
 
ERROR[07-18|17:09:02.634] Downloaded item processing failed        number=34 hash=c23e8d..93d6d8 err="remote block hash is different from being processed one locally (remote=0xc23e8d6534221e798f0aa7c8a08b10f9409c4af1a719eac9c076e2727a93d6d8, local=0x5046a9ee7ae0c431a652dac7d84442730ca07cf72faecc11a87783bca669502a)"
INFO [07-18|17:09:02.634] Block synchronisation finished 
WARN [07-18|17:09:02.635] Synchronisation failed, dropping peer    peer=f6215791327f1b5a52a763297a5263407a92ea2fa586a7b887410ef9e5b6800d err="retrieved hash chain is invalid: remote block hash is different from being processed one locally (remote=0xc23e8d6534221e798f0aa7c8a08b10f9409c4af1a719eac9c076e2727a93d6d8, local=0x5046a9ee7ae0c431a652dac7d84442730ca07cf72faecc11a87783bca669502a)"
```