### PR TITLE
feat: add eth 68 protocol

### DIFF
--- a/cmd/devp2p/internal/ethtest/types.go
+++ b/cmd/devp2p/internal/ethtest/types.go
@@ -116,6 +116,10 @@ type NewPooledTransactionHashes eth.NewPooledTransactionHashesPacket
 
 func (nb NewPooledTransactionHashes) Code() int { return 24 }
 
+type NewPooledTransactionHashes68 eth.NewPooledTransactionHashesPacket68
+
+func (nb NewPooledTransactionHashes68) Code() int { return 24 }
+
 type GetPooledTransactions eth.GetPooledTransactionsPacket
 
 func (gpt GetPooledTransactions) Code() int { return 25 }

--- a/core/rawdb/accessors_chain.go
+++ b/core/rawdb/accessors_chain.go
@@ -334,8 +334,8 @@ func ReadHeaderRange(db ethdb.Reader, number uint64, count uint64) []rlp.RawValu
 		return rlpHeaders
 	}
 	// read remaining from ancients
-	max := count * 700
-	data, err := db.AncientRange(freezerHeaderTable, i+1-count, count, max)
+	maxBytes := count * 8000 // WEMIX mainnet block header size is 4K bytes in normal
+	data, err := db.AncientRange(freezerHeaderTable, i+1-count, count, maxBytes)
 	if err == nil && uint64(len(data)) == count {
 		// the data is on the order [h, h+1, .., n] -- reordering needed
 		for i := range data {

--- a/eth/handler_eth.go
+++ b/eth/handler_eth.go
@@ -70,6 +70,9 @@ func (h *ethHandler) Handle(peer *eth.Peer, packet eth.Packet) error {
 	case *eth.NewPooledTransactionHashesPacket:
 		return h.txFetcher.Notify(peer.ID(), *packet)
 
+	case *eth.NewPooledTransactionHashesPacket68:
+		return h.txFetcher.Notify(peer.ID(), packet.Hashes)
+
 	case *eth.TransactionsPacket:
 		return h.txFetcher.Enqueue(peer.ID(), *packet, false)
 

--- a/eth/handler_eth_test.go
+++ b/eth/handler_eth_test.go
@@ -82,6 +82,7 @@ func (h *testEthHandler) Handle(peer *eth.Peer, packet eth.Packet) error {
 // fork IDs in the protocol handshake.
 func TestForkIDSplit65(t *testing.T) { testForkIDSplit(t, eth.ETH65) }
 func TestForkIDSplit66(t *testing.T) { testForkIDSplit(t, eth.ETH66) }
+func TestForkIDSplit68(t *testing.T) { testForkIDSplit(t, eth.ETH68) }
 
 func testForkIDSplit(t *testing.T, protocol uint) {
 	t.Parallel()
@@ -240,6 +241,7 @@ func testForkIDSplit(t *testing.T, protocol uint) {
 // Tests that received transactions are added to the local pool.
 func TestRecvTransactions65(t *testing.T) { testRecvTransactions(t, eth.ETH65) }
 func TestRecvTransactions66(t *testing.T) { testRecvTransactions(t, eth.ETH66) }
+func TestRecvTransactions68(t *testing.T) { testRecvTransactions(t, eth.ETH68) }
 
 func testRecvTransactions(t *testing.T, protocol uint) {
 	t.Parallel()
@@ -297,6 +299,7 @@ func testRecvTransactions(t *testing.T, protocol uint) {
 
 // This test checks that pending transactions are sent.
 func TestSendTransactions66(t *testing.T) { testSendTransactions(t, eth.ETH66) }
+func TestSendTransactions68(t *testing.T) { testSendTransactions(t, eth.ETH68) }
 
 func testSendTransactions(t *testing.T, protocol uint) {
 	t.Parallel()
@@ -383,6 +386,7 @@ func testSendTransactions(t *testing.T, protocol uint) {
 // broadcasts or via announcements/retrievals.
 func TestTransactionPropagation65(t *testing.T) { testTransactionPropagation(t, eth.ETH65) }
 func TestTransactionPropagation66(t *testing.T) { testTransactionPropagation(t, eth.ETH66) }
+func TestTransactionPropagation68(t *testing.T) { testTransactionPropagation(t, eth.ETH68) }
 
 func testTransactionPropagation(t *testing.T, protocol uint) {
 	t.Parallel()
@@ -690,6 +694,7 @@ func testBroadcastBlock(t *testing.T, peers, bcasts int) {
 // with the hashes in the header) gets discarded and not broadcast forward.
 func TestBroadcastMalformedBlock65(t *testing.T) { testBroadcastMalformedBlock(t, eth.ETH65) }
 func TestBroadcastMalformedBlock66(t *testing.T) { testBroadcastMalformedBlock(t, eth.ETH66) }
+func TestBroadcastMalformedBlock68(t *testing.T) { testBroadcastMalformedBlock(t, eth.ETH68) }
 
 func testBroadcastMalformedBlock(t *testing.T, protocol uint) {
 	t.Parallel()

--- a/eth/handler_eth_test.go
+++ b/eth/handler_eth_test.go
@@ -65,6 +65,10 @@ func (h *testEthHandler) Handle(peer *eth.Peer, packet eth.Packet) error {
 		h.txAnnounces.Send(([]common.Hash)(*packet))
 		return nil
 
+	case *eth.NewPooledTransactionHashesPacket68:
+		h.txAnnounces.Send(packet.Hashes)
+		return nil
+
 	case *eth.TransactionsPacket:
 		h.txBroadcasts.Send(([]*types.Transaction)(*packet))
 		return nil
@@ -358,7 +362,7 @@ func testSendTransactions(t *testing.T, protocol uint) {
 	seen := make(map[common.Hash]struct{})
 	for len(seen) < len(insert) {
 		switch protocol {
-		case 66:
+		case 66, 68:
 			select {
 			case hashes := <-anns:
 				for _, hash := range hashes {

--- a/eth/protocols/eth/broadcast.go
+++ b/eth/protocols/eth/broadcast.go
@@ -142,13 +142,17 @@ func (p *Peer) announceTransactions() {
 		if done == nil && len(queue) > 0 {
 			// Pile transaction hashes until we reach our allowed network limit
 			var (
-				count   int
-				pending []common.Hash
-				size    common.StorageSize
+				count        int
+				pending      []common.Hash
+				pendingTypes []byte
+				pendingSizes []uint32
+				size         common.StorageSize
 			)
 			for count = 0; count < len(queue) && size < maxTxPacketSize; count++ {
-				if p.txpool.Get(queue[count]) != nil {
+				if tx := p.txpool.Get(queue[count]); tx != nil {
 					pending = append(pending, queue[count])
+					pendingTypes = append(pendingTypes, tx.Type())
+					pendingSizes = append(pendingSizes, uint32(tx.Size()))
 					size += common.HashLength
 				}
 			}
@@ -159,9 +163,16 @@ func (p *Peer) announceTransactions() {
 			if len(pending) > 0 {
 				done = make(chan struct{})
 				go func() {
-					if err := p.sendPooledTransactionHashes(pending); err != nil {
-						fail <- err
-						return
+					if p.version >= ETH68 {
+						if err := p.sendPooledTransactionHashes68(pending, pendingTypes, pendingSizes); err != nil {
+							fail <- err
+							return
+						}
+					} else {
+						if err := p.sendPooledTransactionHashes(pending); err != nil {
+							fail <- err
+							return
+						}
 					}
 					close(done)
 					p.Log().Trace("Sent transaction announcements", "count", len(pending))

--- a/eth/protocols/eth/handler.go
+++ b/eth/protocols/eth/handler.go
@@ -102,8 +102,12 @@ func MakeProtocols(backend Backend, network uint64, dnsdisc enode.Iterator) []p2
 	for i, version := range ProtocolVersions {
 		version := version // Closure
 
+		protocolName := ProtocolName
+		if version == ETH68 {
+			protocolName = Protocol68Name
+		}
 		protocols[i] = p2p.Protocol{
-			Name:    ProtocolName,
+			Name:    protocolName,
 			Version: version,
 			Length:  protocolLengths[version],
 			Run: func(p *p2p.Peer, rw p2p.MsgReadWriter) error {

--- a/eth/protocols/eth/handler.go
+++ b/eth/protocols/eth/handler.go
@@ -216,6 +216,21 @@ var eth66 = map[uint64]msgHandler{
 	TransactionsExMsg: handleTransactionsEx,
 }
 
+var eth68 = map[uint64]msgHandler{
+	NewBlockHashesMsg:             handleNewBlockhashes,
+	NewBlockMsg:                   handleNewBlock,
+	TransactionsMsg:               handleTransactions,
+	NewPooledTransactionHashesMsg: handleNewPooledTransactionHashes68,
+	GetBlockHeadersMsg:            handleGetBlockHeaders66,
+	BlockHeadersMsg:               handleBlockHeaders66,
+	GetBlockBodiesMsg:             handleGetBlockBodies66,
+	BlockBodiesMsg:                handleBlockBodies66,
+	GetReceiptsMsg:                handleGetReceipts66,
+	ReceiptsMsg:                   handleReceipts66,
+	GetPooledTransactionsMsg:      handleGetPooledTransactions66,
+	PooledTransactionsMsg:         handlePooledTransactions66,
+}
+
 // handleMessage is invoked whenever an inbound message is received from a remote
 // peer. The remote connection is torn down upon returning any error.
 func handleMessage(backend Backend, peer *Peer) error {
@@ -230,8 +245,11 @@ func handleMessage(backend Backend, peer *Peer) error {
 	defer msg.Discard()
 
 	var handlers = eth65
-	if peer.Version() >= ETH66 {
+	if peer.Version() == ETH66 {
 		handlers = eth66
+	}
+	if peer.Version() == ETH68 {
+		handlers = eth68
 	}
 
 	// Track the amount of time it takes to serve the request and run the handler

--- a/eth/protocols/eth/handler.go
+++ b/eth/protocols/eth/handler.go
@@ -260,7 +260,7 @@ func handleMessage(backend Backend, peer *Peer) error {
 	if peer.Version() == ETH66 {
 		handlers = eth66
 	}
-	if peer.Version() == ETH68 {
+	if peer.Version() >= ETH68 {
 		handlers = eth68
 	}
 

--- a/eth/protocols/eth/handler_test.go
+++ b/eth/protocols/eth/handler_test.go
@@ -403,11 +403,11 @@ func testGetBlockBodies(t *testing.T, protocol uint) {
 }
 
 // Tests that the state trie nodes can be retrieved based on hashes.
-func TestGetNodeData65(t *testing.T) { testGetNodeData(t, ETH65) }
-func TestGetNodeData66(t *testing.T) { testGetNodeData(t, ETH66) }
-func TestGetNodeData68(t *testing.T) { testGetNodeData(t, ETH68) }
+func TestGetNodeData65(t *testing.T) { testGetNodeData(t, ETH65, false) }
+func TestGetNodeData66(t *testing.T) { testGetNodeData(t, ETH66, false) }
+func TestGetNodeData68(t *testing.T) { testGetNodeData(t, ETH68, true) }
 
-func testGetNodeData(t *testing.T, protocol uint) {
+func testGetNodeData(t *testing.T, protocol uint, drop bool) {
 	t.Parallel()
 
 	// Define three accounts to simulate transactions with
@@ -472,8 +472,15 @@ func testGetNodeData(t *testing.T, protocol uint) {
 		})
 	}
 	msg, err := peer.app.ReadMsg()
-	if err != nil {
-		t.Fatalf("failed to read node data response: %v", err)
+	if !drop {
+		if err != nil {
+			t.Fatalf("failed to read node data response: %v", err)
+		}
+	} else {
+		if err != nil {
+			return
+		}
+		t.Fatalf("succeeded to read node data response on non-supporting protocol: %v", msg)
 	}
 	if msg.Code != NodeDataMsg {
 		t.Fatalf("response packet code mismatch: have %x, want %x", msg.Code, NodeDataMsg)

--- a/eth/protocols/eth/handler_test.go
+++ b/eth/protocols/eth/handler_test.go
@@ -110,6 +110,7 @@ func (b *testBackend) Handle(*Peer, Packet) error {
 // Tests that block headers can be retrieved from a remote chain based on user queries.
 func TestGetBlockHeaders65(t *testing.T) { testGetBlockHeaders(t, ETH65) }
 func TestGetBlockHeaders66(t *testing.T) { testGetBlockHeaders(t, ETH66) }
+func TestGetBlockHeaders68(t *testing.T) { testGetBlockHeaders(t, ETH68) }
 
 func testGetBlockHeaders(t *testing.T, protocol uint) {
 	t.Parallel()
@@ -312,6 +313,7 @@ func testGetBlockHeaders(t *testing.T, protocol uint) {
 // Tests that block contents can be retrieved from a remote chain based on their hashes.
 func TestGetBlockBodies65(t *testing.T) { testGetBlockBodies(t, ETH65) }
 func TestGetBlockBodies66(t *testing.T) { testGetBlockBodies(t, ETH66) }
+func TestGetBlockBodies68(t *testing.T) { testGetBlockBodies(t, ETH68) }
 
 func testGetBlockBodies(t *testing.T, protocol uint) {
 	t.Parallel()
@@ -403,6 +405,7 @@ func testGetBlockBodies(t *testing.T, protocol uint) {
 // Tests that the state trie nodes can be retrieved based on hashes.
 func TestGetNodeData65(t *testing.T) { testGetNodeData(t, ETH65) }
 func TestGetNodeData66(t *testing.T) { testGetNodeData(t, ETH66) }
+func TestGetNodeData68(t *testing.T) { testGetNodeData(t, ETH68) }
 
 func testGetNodeData(t *testing.T, protocol uint) {
 	t.Parallel()
@@ -524,6 +527,7 @@ func testGetNodeData(t *testing.T, protocol uint) {
 // Tests that the transaction receipts can be retrieved based on hashes.
 func TestGetBlockReceipts65(t *testing.T) { testGetBlockReceipts(t, ETH65) }
 func TestGetBlockReceipts66(t *testing.T) { testGetBlockReceipts(t, ETH66) }
+func TestGetBlockReceipts68(t *testing.T) { testGetBlockReceipts(t, ETH68) }
 
 func testGetBlockReceipts(t *testing.T, protocol uint) {
 	t.Parallel()

--- a/eth/protocols/eth/handlers.go
+++ b/eth/protocols/eth/handlers.go
@@ -19,6 +19,7 @@ package eth
 import (
 	"encoding/json"
 	"fmt"
+
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/core"
 	"github.com/ethereum/go-ethereum/core/types"

--- a/eth/protocols/eth/handlers.go
+++ b/eth/protocols/eth/handlers.go
@@ -798,6 +798,33 @@ func handleNewPooledTransactionHashes(backend Backend, msg Decoder, peer *Peer) 
 	return nil
 }
 
+func handleNewPooledTransactionHashes68(backend Backend, msg Decoder, peer *Peer) error {
+	// New transaction announcement arrived, make sure we have
+	// a valid and fresh chain to handle them
+	if !backend.AcceptTxs() {
+		return nil
+	}
+	ann := new(NewPooledTransactionHashesPacket68)
+	if err := msg.Decode(ann); err != nil {
+		return fmt.Errorf("%w: message %v: %v", errDecode, msg, err)
+	}
+	if len(ann.Hashes) != len(ann.Types) || len(ann.Hashes) != len(ann.Sizes) {
+		return fmt.Errorf("%w: message %v: invalid len of fields: %v %v %v", errDecode, msg, len(ann.Hashes), len(ann.Types), len(ann.Sizes))
+	}
+	f := func() error {
+		// Schedule all the unknown hashes for retrieval
+		for _, hash := range ann.Hashes {
+			peer.markTransaction(hash)
+		}
+		return backend.Handle(peer, ann)
+	}
+	if params.ConsensusMethod == params.ConsensusPoW {
+		return f()
+	}
+	go f()
+	return nil
+}
+
 func handleGetPooledTransactions(backend Backend, msg Decoder, peer *Peer) error {
 	// Decode the pooled transactions retrieval message
 	var query GetPooledTransactionsPacket

--- a/eth/protocols/eth/handlers.go
+++ b/eth/protocols/eth/handlers.go
@@ -19,7 +19,6 @@ package eth
 import (
 	"encoding/json"
 	"fmt"
-
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/core"
 	"github.com/ethereum/go-ethereum/core/types"
@@ -143,17 +142,7 @@ func handleGetBlockHeaders66(backend Backend, msg Decoder, peer *Peer) error {
 	}
 	f := func() error {
 		response := ServiceGetBlockHeadersQuery(backend.Chain(), query.GetBlockHeadersPacket, peer)
-		if len(response) == int(query.GetBlockHeadersPacket.Amount) {
-			return peer.ReplyBlockHeadersRLP(query.RequestId, response)
-		} else {
-			// Wemix: fall back to old behavior
-			response2 := answerGetBlockHeadersQuery(backend, query.GetBlockHeadersPacket, peer)
-			if len(response2) > len(response) {
-				return peer.ReplyBlockHeaders(query.RequestId, response2)
-			} else {
-				return peer.ReplyBlockHeadersRLP(query.RequestId, response)
-			}
-		}
+		return peer.ReplyBlockHeadersRLP(query.RequestId, response)
 	}
 	if params.ConsensusMethod == params.ConsensusPoW {
 		return f()

--- a/eth/protocols/eth/peer.go
+++ b/eth/protocols/eth/peer.go
@@ -227,6 +227,12 @@ func (p *Peer) sendPooledTransactionHashes(hashes []common.Hash) error {
 	return p2p.Send(p.rw, NewPooledTransactionHashesMsg, NewPooledTransactionHashesPacket(hashes))
 }
 
+func (p *Peer) sendPooledTransactionHashes68(hashes []common.Hash, types []byte, sizes []uint32) error {
+	// Mark all the transactions as known, but ensure we don't overflow our limits
+	p.knownTxs.Add(hashes...)
+	return p2p.Send(p.rw, NewPooledTransactionHashesMsg, NewPooledTransactionHashesPacket68{Types: types, Sizes: sizes, Hashes: hashes})
+}
+
 // AsyncSendPooledTransactionHashes queues a list of transactions hashes to eventually
 // announce to a remote peer.  The number of pending sends are capped (new ones
 // will force old sends to be dropped)

--- a/eth/protocols/eth/peer_test.go
+++ b/eth/protocols/eth/peer_test.go
@@ -48,6 +48,8 @@ func newTestPeer(name string, version uint, backend Backend) (*testPeer, <-chan 
 	peer := NewPeer(version, p2p.NewPeer(id, name, nil), net, backend.TxPool())
 	errc := make(chan error, 1)
 	go func() {
+		defer app.Close()
+
 		errc <- backend.RunPeer(peer, func(peer *Peer) error {
 			return Handle(backend, peer)
 		})

--- a/eth/protocols/eth/protocol.go
+++ b/eth/protocols/eth/protocol.go
@@ -39,10 +39,8 @@ const (
 // ProtocolName is the official short name of the `eth` protocol used during
 // devp2p capability negotiation.
 const ProtocolName = "mir"
-const Protocol68Name = "eth"
+const ProtocolAlias = "eth"
 
-// ProtocolVersions are the supported versions of the `eth` protocol (first
-// is primary).
 var ProtocolVersions = []uint{ETH68, ETH66, ETH65}
 
 // protocolLengths are the number of implemented message corresponding to

--- a/eth/protocols/eth/protocol.go
+++ b/eth/protocols/eth/protocol.go
@@ -39,6 +39,7 @@ const (
 // ProtocolName is the official short name of the `eth` protocol used during
 // devp2p capability negotiation.
 const ProtocolName = "mir"
+const Protocol68Name = "eth"
 
 // ProtocolVersions are the supported versions of the `eth` protocol (first
 // is primary).

--- a/eth/protocols/eth/protocol.go
+++ b/eth/protocols/eth/protocol.go
@@ -33,6 +33,7 @@ import (
 const (
 	ETH65 = 65
 	ETH66 = 66
+	ETH68 = 68
 )
 
 // ProtocolName is the official short name of the `eth` protocol used during
@@ -41,11 +42,11 @@ const ProtocolName = "mir"
 
 // ProtocolVersions are the supported versions of the `eth` protocol (first
 // is primary).
-var ProtocolVersions = []uint{ETH66, ETH65}
+var ProtocolVersions = []uint{ETH68, ETH66, ETH65}
 
 // protocolLengths are the number of implemented message corresponding to
 // different protocol versions.
-var protocolLengths = map[uint]uint64{ETH66: 23, ETH65: 23}
+var protocolLengths = map[uint]uint64{ETH66: 23, ETH65: 23, ETH68: 17}
 
 // maxMessageSize is the maximum cap on the size of a protocol message.
 const maxMessageSize = 100 * 1024 * 1024
@@ -316,6 +317,13 @@ type ReceiptsRLPPacket66 struct {
 // NewPooledTransactionHashesPacket represents a transaction announcement packet.
 type NewPooledTransactionHashesPacket []common.Hash
 
+// NewPooledTransactionHashesPacket68 represents a transaction announcement packet on eth/68 and newer.
+type NewPooledTransactionHashesPacket68 struct {
+	Types  []byte
+	Sizes  []uint32
+	Hashes []common.Hash
+}
+
 // GetPooledTransactionsPacket represents a transaction query.
 type GetPooledTransactionsPacket []common.Hash
 
@@ -420,6 +428,9 @@ func (*ReceiptsPacket) Kind() byte   { return ReceiptsMsg }
 
 func (*NewPooledTransactionHashesPacket) Name() string { return "NewPooledTransactionHashes" }
 func (*NewPooledTransactionHashesPacket) Kind() byte   { return NewPooledTransactionHashesMsg }
+
+func (*NewPooledTransactionHashesPacket68) Name() string { return "NewPooledTransactionHashes" }
+func (*NewPooledTransactionHashesPacket68) Kind() byte   { return NewPooledTransactionHashesMsg }
 
 func (*GetPooledTransactionsPacket) Name() string { return "GetPooledTransactions" }
 func (*GetPooledTransactionsPacket) Kind() byte   { return GetPooledTransactionsMsg }

--- a/p2p/peer.go
+++ b/p2p/peer.go
@@ -389,11 +389,11 @@ outer:
 			}
 			if proto.Match(cap) {
 				// If an old protocol version matched, revert it
-				if old := result[cap.Name]; old != nil {
+				if old := result[proto.Name]; old != nil {
 					offset -= old.Length
 				}
 				// Assign the new match
-				result[cap.Name] = &protoRW{Protocol: proto, offset: offset, in: make(chan Msg), w: rw}
+				result[proto.Name] = &protoRW{Protocol: proto, offset: offset, in: make(chan Msg), w: rw}
 				offset += proto.Length
 
 				continue outer

--- a/p2p/peer.go
+++ b/p2p/peer.go
@@ -382,7 +382,12 @@ func matchProtocols(protocols []Protocol, caps []Cap, rw MsgReadWriter) map[stri
 outer:
 	for _, cap := range caps {
 		for _, proto := range protocols {
-			if proto.Name == cap.Name && proto.Version == cap.Version {
+			if proto.Match == nil {
+				proto.Match = func(protoName string, protoVersion uint, cap Cap) bool {
+					return protoName == cap.Name && protoVersion == cap.Version
+				}
+			}
+			if proto.Match(proto.Name, proto.Version, cap) {
 				// If an old protocol version matched, revert it
 				if old := result[cap.Name]; old != nil {
 					offset -= old.Length

--- a/p2p/peer.go
+++ b/p2p/peer.go
@@ -365,7 +365,12 @@ func countMatchingProtocols(protocols []Protocol, caps []Cap) int {
 	n := 0
 	for _, cap := range caps {
 		for _, proto := range protocols {
-			if proto.Name == cap.Name && proto.Version == cap.Version {
+			if proto.Match == nil {
+				proto.Match = func(cap Cap) bool {
+					return proto.Name == cap.Name && proto.Version == cap.Version
+				}
+			}
+			if proto.Match(cap) {
 				n++
 			}
 		}

--- a/p2p/peer.go
+++ b/p2p/peer.go
@@ -383,11 +383,11 @@ outer:
 	for _, cap := range caps {
 		for _, proto := range protocols {
 			if proto.Match == nil {
-				proto.Match = func(protoName string, protoVersion uint, cap Cap) bool {
-					return protoName == cap.Name && protoVersion == cap.Version
+				proto.Match = func(cap Cap) bool {
+					return proto.Name == cap.Name && proto.Version == cap.Version
 				}
 			}
-			if proto.Match(proto.Name, proto.Version, cap) {
+			if proto.Match(cap) {
 				// If an old protocol version matched, revert it
 				if old := result[cap.Name]; old != nil {
 					offset -= old.Length

--- a/p2p/protocol.go
+++ b/p2p/protocol.go
@@ -23,6 +23,8 @@ import (
 	"github.com/ethereum/go-ethereum/p2p/enr"
 )
 
+type matchFunc func(protoName string, protoVersion uint, cap Cap) bool
+
 // Protocol represents a P2P subprotocol implementation.
 type Protocol struct {
 	// Name should contain the official protocol name,
@@ -61,6 +63,9 @@ type Protocol struct {
 
 	// Attributes contains protocol specific information for the node record.
 	Attributes []enr.Entry
+
+	// WEMIX: for supporting ETH protocol name
+	Match matchFunc
 }
 
 func (p Protocol) cap() Cap {

--- a/p2p/protocol.go
+++ b/p2p/protocol.go
@@ -23,7 +23,8 @@ import (
 	"github.com/ethereum/go-ethereum/p2p/enr"
 )
 
-type matchFunc func(protoName string, protoVersion uint, cap Cap) bool
+type matchFunc func(cap Cap) bool
+type representativeNameFunc func() string
 
 // Protocol represents a P2P subprotocol implementation.
 type Protocol struct {
@@ -65,11 +66,15 @@ type Protocol struct {
 	Attributes []enr.Entry
 
 	// WEMIX: for supporting ETH protocol name
-	Match matchFunc
+	Match              matchFunc
+	RepresentativeName representativeNameFunc
 }
 
 func (p Protocol) cap() Cap {
-	return Cap{p.Name, p.Version}
+	if p.RepresentativeName == nil {
+		return Cap{p.Name, p.Version}
+	}
+	return Cap{p.RepresentativeName(), p.Version}
 }
 
 // Cap is the structure of a peer capability.

--- a/wemix/bind/structs.go
+++ b/wemix/bind/structs.go
@@ -36,8 +36,8 @@ type GovContracts struct {
 	BallotStorageImp *BallotStorageImp
 	EnvStorage       *EnvStorage
 	EnvStorageImp    *EnvStorageImp
-	NCPExit          *NCPExit
-	NCPExitImp       *NCPExitImp
+	NCPExit          *NCPExit    // not used; only used for deploying gov contracts
+	NCPExitImp       *NCPExitImp // not used; only used for deploying gov contracts
 	address          struct {
 		Registry      common.Address
 		Gov           common.Address
@@ -76,9 +76,8 @@ func NewGovContracts(backend bind.ContractBackend, registry common.Address) (*Go
 		return nil, errors.Wrap(err, DOMAIN_BallotStorage)
 	} else if gov.address.EnvStorage, gov.EnvStorage, gov.EnvStorageImp, err = newUUPSContracts(cfg, DOMAIN_EnvStorage, NewEnvStorage, NewEnvStorageImp); err != nil {
 		return nil, errors.Wrap(err, DOMAIN_EnvStorage)
-	} else if gov.address.NCPExit, gov.NCPExit, gov.NCPExitImp, err = newUUPSContracts(cfg, DOMAIN_NCPExit, NewNCPExit, NewNCPExitImp); err != nil {
-		return nil, errors.Wrap(err, DOMAIN_NCPExit)
 	} else {
+		// NCPExit and NCPExitImp are not loaded. It can be nil at the block that is gov contracts were deployed in
 		return gov, nil
 	}
 }


### PR DESCRIPTION
This PR adds "eth68" protocol to go-wemix as it makes new go-wemix based on go-ethereum 1.13 possible to synchronize with legacy WEMIX network.

go-ethereum v1.13 has no eth-65(renamed to mir-65), eth-66(mir-66) protocol which is used by go-wemix legacy, so we need to add `eth-66(mir-66)` protocol to new go-wemix based on go-ethereum 1.13 or to add `eth-68` protocol to legacy wemix nodes.

But it's not good solution to add `eth-66(mir-66)` protocol to new go-wemix because porting legacy code to new product makes us hard to merge new go-ethereum updates. So I added `eth-68` protocol to go-wemix.

If we develop new go-wemix, several public EN nodes should be upgraded with a version having this `eth-68` protocol so that new go-wemix can synchronize WEMIX legacy chain.

I refer this PR(https://github.com/ethereum/go-ethereum/pull/25980) from go-ethereum repository.

And following WEMIX extended protocol of mir-65, mir-66 is not ported because these protocol is not used or required only to BP nodes.

```
GetPendingTxsMsg  = 0x11
GetStatusExMsg    = 0x12
StatusExMsg       = 0x13
EtcdAddMemberMsg  = 0x14
EtcdClusterMsg    = 0x15
TransactionsExMsg = 0x16
```

As a result, the protocols supported by each node are as follows.
- Legacy go-wemix: mir-65, mir-66, eth-68(optional)
- New go-wemix base on go-ethereum 1.13: eth-68

And I tested on `devnet` chain.
1) upgrade an EN node with this PR. (it enables `eth-68` protocol on the EN)
2) on local PC, I boot up an EN which has only `eth-68` protocol (disabled `mir-65`, `mir-66`)
3) this local node can synchronize blocks from genesis: success
4) this local node can import new created block after finishing sync: success
