### PR TITLE
ci: update devnet ci

### DIFF
--- a/.github/workflows/devnet-ci.yml
+++ b/.github/workflows/devnet-ci.yml
@@ -27,7 +27,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        version: [1.17, 1.18, 1.19]
+        version: [1.18, 1.19]
     runs-on: ubuntu-20.04
     steps:
     - uses: actions/checkout@v3
@@ -48,6 +48,9 @@ jobs:
     - uses: actions/checkout@v3
       with:
         ref: ${{ github.event.pull_request.head.sha }}
+
+    - name: Set up Wemix Submodules
+      run: git submodule update --init wemix/
 
     - name: Set up Go
       uses: actions/setup-go@v3


### PR DESCRIPTION
1. make lint test for devnet consistent with dev's, which i removed lint test for go 1.17
2. init submodule below `wemix/` folder to prevent unit test failure ( specifically, openzepplin submodule) 
