### PR TITLE
ci: artifact and release ci script

### DIFF
--- a/.github/workflows/artifacts.yml
+++ b/.github/workflows/artifacts.yml
@@ -5,7 +5,6 @@ on:
     branches:
       - devnet
       - master
-      - ci-test
 
 jobs:
 

--- a/.github/workflows/artifacts.yml
+++ b/.github/workflows/artifacts.yml
@@ -5,6 +5,7 @@ on:
     branches:
       - devnet
       - master
+      - ci-test
 
 jobs:
 
@@ -20,7 +21,8 @@ jobs:
 
     - name: Setup packages
       run: |
-        sudo apt install -y libjemalloc-dev liblz4-dev libsnappy-dev libzstd-dev libudev-dev
+        sudo apt-get update
+        sudo apt-get install -y libjemalloc-dev liblz4-dev libsnappy-dev libzstd-dev libudev-dev
         sudo apt remove -y bzip2 libbz2-dev zlib1g-dev
 
     - name: Build Go-WEMIX tarball

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -19,7 +19,8 @@ jobs:
 
     - name: Setup packages
       run: |
-        sudo apt install -y libjemalloc-dev liblz4-dev libsnappy-dev libzstd-dev libudev-dev
+        sudo apt-get update
+        sudo apt-get install -y libjemalloc-dev liblz4-dev libsnappy-dev libzstd-dev libudev-dev
         sudo apt remove -y bzip2 libbz2-dev zlib1g-dev
 
     - name: Build Go-WEMIX tarball (rocksdb)


### PR DESCRIPTION
ci script for creating artifact and release stuck in `404 not found` error while downloading ubuntu packages.

The work is to add `apt-get update` command before installing packages to prevent the above error.