### PR TITLE
implement montblanc hard fork

### DIFF
--- a/consensus/ethash/consensus.go
+++ b/consensus/ethash/consensus.go
@@ -319,8 +319,8 @@ func (ethash *Ethash) verifyHeader(chain consensus.ChainHeaderReader, header, pa
 	if err := misc.VerifyForkHashes(chain.Config(), header, uncle); err != nil {
 		return err
 	}
-	// Wemix: Verify if the parent block is SPoA block
-	if chain.Config().IsMontBlanc(parent.Number) {
+	// Wemix: Verify SPoA block
+	if chain.Config().IsMontBlanc(header.Number) {
 		return fmt.Errorf("go-wemix does not support mont blanc fork")
 	}
 	// Wemix: Check if it's generated and signed by a registered node

--- a/consensus/ethash/consensus.go
+++ b/consensus/ethash/consensus.go
@@ -319,8 +319,8 @@ func (ethash *Ethash) verifyHeader(chain consensus.ChainHeaderReader, header, pa
 	if err := misc.VerifyForkHashes(chain.Config(), header, uncle); err != nil {
 		return err
 	}
-	// Wemix: Verify SPoA block
-	if chain.Config().IsMontBlanc(header.Number) {
+	// Wemix: Verify if the parent block is SPoA block
+	if chain.Config().IsMontBlanc(parent.Number) {
 		return fmt.Errorf("go-wemix does not support mont blanc fork")
 	}
 	// Wemix: Check if it's generated and signed by a registered node

--- a/consensus/ethash/consensus.go
+++ b/consensus/ethash/consensus.go
@@ -321,7 +321,7 @@ func (ethash *Ethash) verifyHeader(chain consensus.ChainHeaderReader, header, pa
 	}
 	// Wemix: Verify SPoA block
 	if chain.Config().IsMontBlanc(header.Number) {
-		return fmt.Errorf("go-wemix does not support mont blanc fork")
+		return fmt.Errorf("go-wemix does not support blocks after MontBlanc hard fork")
 	}
 	// Wemix: Check if it's generated and signed by a registered node
 	if !wemixminer.IsPoW() && !wemixminer.VerifyBlockSig(header.Number, header.Coinbase, header.MinerNodeId, header.Root, header.MinerNodeSig, chain.Config().IsPangyo(header.Number)) {

--- a/consensus/ethash/consensus.go
+++ b/consensus/ethash/consensus.go
@@ -319,6 +319,10 @@ func (ethash *Ethash) verifyHeader(chain consensus.ChainHeaderReader, header, pa
 	if err := misc.VerifyForkHashes(chain.Config(), header, uncle); err != nil {
 		return err
 	}
+	// Wemix: Verify SPoA block
+	if chain.Config().IsMontBlanc(header.Number) {
+		return fmt.Errorf("go-wemix does not support mont blanc fork")
+	}
 	// Wemix: Check if it's generated and signed by a registered node
 	if !wemixminer.IsPoW() && !wemixminer.VerifyBlockSig(header.Number, header.Coinbase, header.MinerNodeId, header.Root, header.MinerNodeSig, chain.Config().IsPangyo(header.Number)) {
 		return consensus.ErrUnauthorized

--- a/miner/worker.go
+++ b/miner/worker.go
@@ -385,6 +385,11 @@ func (w *worker) pendingBlockAndReceipts() (*types.Block, types.Receipts) {
 
 // start sets the running status as 1 and triggers new work submitting.
 func (w *worker) start() {
+	if w.chainConfig.IsMontBlanc(w.chain.CurrentBlock().Number()) {
+		log.Warn("go-wemix only supports SPoA network, please transition new ones with supporting PoS network")
+		return
+	}
+
 	atomic.StoreInt32(&w.running, 1)
 	w.startCh <- struct{}{}
 }

--- a/miner/worker.go
+++ b/miner/worker.go
@@ -1597,8 +1597,8 @@ func (w *worker) commitWork(interrupt *int32, noempty bool, timestamp int64) {
 	}
 	parent := w.chain.CurrentBlock()
 	height := new(big.Int).Add(parent.Number(), common.Big1)
-	// Wemix: Skip blocks after mont blanc fork
-	if w.chain.Config().IsMontBlanc(height) {
+	// Wemix: Skip work if parent block is mont blanc fork
+	if w.chain.Config().IsMontBlanc(parent.Number()) {
 		log.Warn("go-wemix skips mining due to mont blanc fork", "height", height, "parent-hash", parent.Hash())
 		return
 	}

--- a/miner/worker.go
+++ b/miner/worker.go
@@ -1600,9 +1600,14 @@ func (w *worker) commitWork(interrupt *int32, noempty bool, timestamp int64) {
 	} else {
 		return
 	}
+	parent := w.chain.CurrentBlock()
+	height := new(big.Int).Add(parent.Number(), common.Big1)
+	// Wemix: Skip blocks after mont blanc fork
+	if w.chain.Config().IsMontBlanc(height) {
+		log.Warn("go-wemix skips mining due to mont blanc fork", "height", height, "parent-hash", parent.Hash())
+		return
+	}
 	if !wemixminer.IsPoW() {
-		parent := w.chain.CurrentBlock()
-		height := new(big.Int).Add(parent.Number(), common.Big1)
 		ok, err := wemixminer.AcquireMiningToken(height, parent.Hash())
 		if ok {
 			log.Debug("Mining Token, successful", "height", height, "parent-hash", parent.Hash())

--- a/miner/worker.go
+++ b/miner/worker.go
@@ -1597,9 +1597,9 @@ func (w *worker) commitWork(interrupt *int32, noempty bool, timestamp int64) {
 	}
 	parent := w.chain.CurrentBlock()
 	height := new(big.Int).Add(parent.Number(), common.Big1)
-	// Wemix: Skip blocks after mont blanc fork
+	// Wemix: Skip blocks after MontBlanc hard fork
 	if w.chain.Config().IsMontBlanc(height) {
-		log.Warn("go-wemix skips mining due to mont blanc fork", "height", height, "parent-hash", parent.Hash())
+		log.Warn("go-wemix skips mining due to MontBlanc hard fork", "height", height, "parent-hash", parent.Hash())
 		return
 	}
 	if !wemixminer.IsPoW() {

--- a/miner/worker.go
+++ b/miner/worker.go
@@ -385,11 +385,6 @@ func (w *worker) pendingBlockAndReceipts() (*types.Block, types.Receipts) {
 
 // start sets the running status as 1 and triggers new work submitting.
 func (w *worker) start() {
-	if w.chainConfig.IsMontBlanc(w.chain.CurrentBlock().Number()) {
-		log.Warn("go-wemix only supports SPoA network, please transition new ones with supporting PoS network")
-		return
-	}
-
 	atomic.StoreInt32(&w.running, 1)
 	w.startCh <- struct{}{}
 }

--- a/miner/worker.go
+++ b/miner/worker.go
@@ -1597,8 +1597,8 @@ func (w *worker) commitWork(interrupt *int32, noempty bool, timestamp int64) {
 	}
 	parent := w.chain.CurrentBlock()
 	height := new(big.Int).Add(parent.Number(), common.Big1)
-	// Wemix: Skip work if parent block is mont blanc fork
-	if w.chain.Config().IsMontBlanc(parent.Number()) {
+	// Wemix: Skip blocks after mont blanc fork
+	if w.chain.Config().IsMontBlanc(height) {
 		log.Warn("go-wemix skips mining due to mont blanc fork", "height", height, "parent-hash", parent.Hash())
 		return
 	}

--- a/params/config.go
+++ b/params/config.go
@@ -321,16 +321,16 @@ var (
 	//
 	// This configuration is intentionally not using keyed fields to force anyone
 	// adding flags to the config to also have to set these fields.
-	AllEthashProtocolChanges = &ChainConfig{big.NewInt(1337), big.NewInt(0), nil, false, big.NewInt(0), common.Hash{}, big.NewInt(0), big.NewInt(0), big.NewInt(0), big.NewInt(0), big.NewInt(0), big.NewInt(0), big.NewInt(0), big.NewInt(0), big.NewInt(0), big.NewInt(0), nil, nil, nil, nil, nil, new(EthashConfig), nil, nil}
+	AllEthashProtocolChanges = &ChainConfig{big.NewInt(1337), big.NewInt(0), nil, false, big.NewInt(0), common.Hash{}, big.NewInt(0), big.NewInt(0), big.NewInt(0), big.NewInt(0), big.NewInt(0), big.NewInt(0), big.NewInt(0), big.NewInt(0), big.NewInt(0), big.NewInt(0), nil, nil, nil, nil, nil, nil, new(EthashConfig), nil, nil}
 
 	// AllCliqueProtocolChanges contains every protocol change (EIPs) introduced
 	// and accepted by the Ethereum core developers into the Clique consensus.
 	//
 	// This configuration is intentionally not using keyed fields to force anyone
 	// adding flags to the config to also have to set these fields.
-	AllCliqueProtocolChanges = &ChainConfig{big.NewInt(1337), big.NewInt(0), nil, false, big.NewInt(0), common.Hash{}, big.NewInt(0), big.NewInt(0), big.NewInt(0), big.NewInt(0), big.NewInt(0), big.NewInt(0), big.NewInt(0), big.NewInt(0), big.NewInt(0), nil, nil, nil, nil, nil, nil, nil, &CliqueConfig{Period: 0, Epoch: 30000}, nil}
+	AllCliqueProtocolChanges = &ChainConfig{big.NewInt(1337), big.NewInt(0), nil, false, big.NewInt(0), common.Hash{}, big.NewInt(0), big.NewInt(0), big.NewInt(0), big.NewInt(0), big.NewInt(0), big.NewInt(0), big.NewInt(0), big.NewInt(0), big.NewInt(0), nil, nil, nil, nil, nil, nil, nil, nil, &CliqueConfig{Period: 0, Epoch: 30000}, nil}
 
-	TestChainConfig = &ChainConfig{big.NewInt(1), big.NewInt(0), nil, false, big.NewInt(0), common.Hash{}, big.NewInt(0), big.NewInt(0), big.NewInt(0), big.NewInt(0), big.NewInt(0), big.NewInt(0), big.NewInt(0), big.NewInt(0), big.NewInt(0), big.NewInt(0), nil, nil, nil, nil, nil, new(EthashConfig), nil, nil}
+	TestChainConfig = &ChainConfig{big.NewInt(1), big.NewInt(0), nil, false, big.NewInt(0), common.Hash{}, big.NewInt(0), big.NewInt(0), big.NewInt(0), big.NewInt(0), big.NewInt(0), big.NewInt(0), big.NewInt(0), big.NewInt(0), big.NewInt(0), big.NewInt(0), nil, nil, nil, nil, nil, nil, new(EthashConfig), nil, nil}
 	TestRules       = TestChainConfig.Rules(new(big.Int), false)
 )
 
@@ -414,6 +414,7 @@ type ChainConfig struct {
 	PangyoBlock         *big.Int `json:"pangyoBlock,omitempty"`         // Pangyo switch block (nil = no fork, 0 = already on pangyo)
 	ApplepieBlock       *big.Int `json:"applepieBlock,omitempty"`       // Applepie switch block (nil = no fork, 0 = already on applepie)
 	BriocheBlock        *big.Int `json:"briocheBlock,omitempty"`        // Brioche switch block (nil = no fork, 0 = already on brioche)
+	MontBlancBlock      *big.Int `json:"montBlancBlock,omitempty"`      // MontBlanc switch block (nil = no fork, 0 = already on MontBlanc)
 
 	// TerminalTotalDifficulty is the amount of total difficulty reached by
 	// the network that triggers the consensus upgrade.
@@ -509,7 +510,7 @@ func (c *ChainConfig) String() string {
 	default:
 		engine = "unknown"
 	}
-	return fmt.Sprintf("{ChainID: %v Homestead: %v DAO: %v DAOSupport: %v EIP150: %v EIP155: %v EIP158: %v Byzantium: %v Constantinople: %v Petersburg: %v Istanbul: %v, Muir Glacier: %v, Berlin: %v, London: %v, Arrow Glacier: %v, MergeFork: %v, PangyoFork: %v, ApplepieFork: %v, BriocheFork: %v, Terminal TD: %v, BriocheConfig: %v, Engine: %v}",
+	return fmt.Sprintf("{ChainID: %v Homestead: %v DAO: %v DAOSupport: %v EIP150: %v EIP155: %v EIP158: %v Byzantium: %v Constantinople: %v Petersburg: %v Istanbul: %v, Muir Glacier: %v, Berlin: %v, London: %v, Arrow Glacier: %v, MergeFork: %v, PangyoFork: %v, ApplepieFork: %v, BriocheFork: %v, MontBlancFork: %v, Terminal TD: %v, BriocheConfig: %v, Engine: %v}",
 		c.ChainID,
 		c.HomesteadBlock,
 		c.DAOForkBlock,
@@ -529,6 +530,7 @@ func (c *ChainConfig) String() string {
 		c.PangyoBlock,
 		c.ApplepieBlock,
 		c.BriocheBlock,
+		c.MontBlancBlock,
 		c.TerminalTotalDifficulty,
 		c.Brioche,
 		engine,
@@ -617,6 +619,10 @@ func (c *ChainConfig) IsBrioche(num *big.Int) bool {
 	return isForked(c.BriocheBlock, num)
 }
 
+func (c *ChainConfig) IsMontBlanc(num *big.Int) bool {
+	return isForked(c.MontBlancBlock, num)
+}
+
 // IsTerminalPoWBlock returns whether the given block is the last block of PoW stage.
 func (c *ChainConfig) IsTerminalPoWBlock(parentTotalDiff *big.Int, totalDiff *big.Int) bool {
 	if c.TerminalTotalDifficulty == nil {
@@ -675,6 +681,7 @@ func (c *ChainConfig) CheckConfigForkOrder() error {
 		{name: "pangyoBlock", block: c.PangyoBlock, optional: true},
 		{name: "applepieBlock", block: c.ApplepieBlock, optional: true},
 		{name: "briocheBlock", block: c.BriocheBlock, optional: true},
+		{name: "montBlancBlock", block: c.MontBlancBlock, optional: true},
 	} {
 		if lastFork.name != "" {
 			// Next one must be higher number
@@ -759,6 +766,9 @@ func (c *ChainConfig) checkCompatible(newcfg *ChainConfig, head *big.Int) *Confi
 	if isForkIncompatible(c.BriocheBlock, newcfg.BriocheBlock, head) {
 		return newCompatError("Brioche fork block", c.BriocheBlock, newcfg.BriocheBlock)
 	}
+	if isForkIncompatible(c.MontBlancBlock, newcfg.MontBlancBlock, head) {
+		return newCompatError("Mont Blanc fork block", c.MontBlancBlock, newcfg.MontBlancBlock)
+	}
 	return nil
 }
 
@@ -828,7 +838,7 @@ type Rules struct {
 	IsByzantium, IsConstantinople, IsPetersburg, IsIstanbul bool
 	IsBerlin, IsLondon                                      bool
 	IsMerge                                                 bool
-	IsPangyo, IsApplepie, IsBrioche                         bool
+	IsPangyo, IsApplepie, IsBrioche, IsMontBlanc            bool
 }
 
 // Rules ensures c's ChainID is not nil.
@@ -853,5 +863,6 @@ func (c *ChainConfig) Rules(num *big.Int, isMerge bool) Rules {
 		IsPangyo:         c.IsPangyo(num),
 		IsApplepie:       c.IsApplepie(num),
 		IsBrioche:        c.IsBrioche(num),
+		IsMontBlanc:      c.IsMontBlanc(num),
 	}
 }


### PR DESCRIPTION
After the block reached to mont blanc fork, mining worker skips committing work for the futher mont blanc blocks.
Instead, warning log appears constantly:
```
WARN [09-24|01:21:30.277] go-wemix skips mining due to mont blanc fork height=30 parent-hash=11cc16..c0ea5f
WARN [09-24|01:21:31.277] go-wemix skips mining due to mont blanc fork height=30 parent-hash=11cc16..c0ea5f
```

In addition, mont blanc block excluding the block generated at fork time is filtered out during header verification.
```
DEBUG[09-25|10:07:14.819] Propagated block verification failed     peer=72c3d5b3a6972776253f2e535dcb52199e6fbf58cce653bcb80eab965e97e2ce number=10,867,700 hash=17583b..92886c err="go-wemix does not support mont blanc fork"
DEBUG[09-25|10:07:14.819] Message handling failed in `eth`         id=72c3d5b3a6972776 conn=staticdial err=EOF
DEBUG[09-25|10:07:14.819] Removing Ethereum peer                   peer=72c3d5b3 snap=true
DEBUG[09-25|10:07:14.819] Message handling failed in `snap`        peer=72c3d5b3 err=EOF
DEBUG[09-25|10:07:14.819] Removing p2p peer                        peercount=1 id=72c3d5b3a6972776 duration=32.627s     req=false err="useless peer"
```