### PR TITLE
ci: upgrade ubuntu version for master (#151)

### DIFF
--- a/.github/workflows/artifacts.yml
+++ b/.github/workflows/artifacts.yml
@@ -9,7 +9,7 @@ on:
 jobs:
 
   build:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     steps:
     - uses: actions/checkout@v4
 

--- a/.github/workflows/dev-ci.yml
+++ b/.github/workflows/dev-ci.yml
@@ -7,7 +7,7 @@ on:
 
 jobs:
   build_test:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     steps:
     - uses: actions/checkout@v3
       with:
@@ -28,7 +28,7 @@ jobs:
       fail-fast: false
       matrix:
         version: [1.18, 1.19]
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     steps:
     - uses: actions/checkout@v3
       with:
@@ -43,7 +43,7 @@ jobs:
       run: make lint
 
   unit_test:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     steps:
     - uses: actions/checkout@v3
       with:

--- a/.github/workflows/dev-cron.yml
+++ b/.github/workflows/dev-cron.yml
@@ -6,7 +6,7 @@ on:
 
 jobs:
   build_test:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     steps:
     - uses: actions/checkout@v3
       with:
@@ -27,7 +27,7 @@ jobs:
       fail-fast: false
       matrix:
         version: [1.17, 1.18, 1.19]
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     steps:
     - uses: actions/checkout@v3
       with:
@@ -42,7 +42,7 @@ jobs:
       run: make lint
 
   unit_test:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     steps:
     - uses: actions/checkout@v3
       with:

--- a/.github/workflows/gwemix-ci.yml
+++ b/.github/workflows/gwemix-ci.yml
@@ -7,7 +7,7 @@ on:
 
 jobs:
   build_test:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     steps:
     - uses: actions/checkout@v3
       with:
@@ -28,7 +28,7 @@ jobs:
       fail-fast: false
       matrix:
         version: [1.18, 1.19]
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     steps:
     - uses: actions/checkout@v3
       with:
@@ -43,7 +43,7 @@ jobs:
       run: make lint
 
   unit_test:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     steps:
     - uses: actions/checkout@v3
       with:

--- a/.github/workflows/master-ci.yml
+++ b/.github/workflows/master-ci.yml
@@ -7,7 +7,7 @@ on:
 
 jobs:
   build_test:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     steps:
     - uses: actions/checkout@v3
       with:
@@ -28,7 +28,7 @@ jobs:
       fail-fast: false
       matrix:
         version: [1.18, 1.19]
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     steps:
     - uses: actions/checkout@v3
       with:
@@ -43,7 +43,7 @@ jobs:
       run: make lint
 
   unit_test:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     steps:
     - uses: actions/checkout@v3
       with:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -8,7 +8,7 @@ on:
 jobs:
 
   build:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     steps:
     - uses: actions/checkout@v4
 


### PR DESCRIPTION
- merge dev(upgrade ubuntu) to master
- please ignore the failure of devnet-ci (it will work after [#155](https://github.com/wemixarchive/go-wemix/pull/155) is merged)