### PR TITLE
hotfix: prevent creating blocks with an incorrect coinbase

### DIFF
--- a/miner/worker.go
+++ b/miner/worker.go
@@ -1631,13 +1631,17 @@ func (w *worker) commitWork(interrupt *int32, noempty bool, timestamp int64) {
 		timestamp: uint64(timestamp),
 		coinbase:  coinbase,
 	})
+	if err != nil {
+		log.Error("Error in preparing work", "err", err)
+		return
+	}
 	if !wemixminer.IsPoW() { // Wemix
 		if coinbase, err := wemixminer.GetCoinbase(work.header.Number); err == nil {
 			work.coinbase = coinbase
+		} else {
+			log.Error("Error in getting coinbase", "err", err)
+			return
 		}
-	}
-	if err != nil {
-		return
 	}
 
 	if !wemixminer.IsPoW() { // Wemix


### PR DESCRIPTION
Fixed an issue where `commitWork` did not abort upon failing to get the coinbase during mining. This lack of error handling led to creating and propagating blocks with an incorrect coinbase.

This will be included in v0.10.10 (through hotfix)