### PR TITLE
ci: add write permissions to release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -5,6 +5,9 @@ on:
     tags:
       - w*
 
+permissions:
+  contents: write
+
 jobs:
 
   build:


### PR DESCRIPTION
- Added `contents: write` permission to the release workflow to enable release creation.