### PR TITLE
fix(governance): harden GovImp against CertiK W1G findings

### DIFF
--- a/wemix/governance-contract/contracts/mock/GovImpLegacy.sol
+++ b/wemix/governance-contract/contracts/mock/GovImpLegacy.sol
@@ -1,18 +1,35 @@
 // SPDX-License-Identifier: MIT
 pragma solidity ^0.8.0;
 
-import "@openzeppelin/contracts-upgradeable/security/ReentrancyGuardUpgradeable.sol";
-import "./abstract/BallotEnums.sol";
-import "./abstract/EnvConstants.sol";
-import "./abstract/AGov.sol";
+// =============================================================================
+// TEST-ONLY MOCK — DO NOT DEPLOY TO PRODUCTION.
+//
+// GovImpLegacy is a byte-for-byte copy of GovImp.sol *before* the CertiK W1G
+// fixes (W1G-01/02/03/04) were applied. It exists so the Go test suite can:
+//   1. deploy the UNFIXED implementation behind the real Gov proxy,
+//   2. build up a realistic on-chain ledger (multiple stakers, some with a
+//      self-separated staker/voter/reward), and
+//   3. reproduce each vulnerability on that ledger (the "red" proof),
+//   4. then upgrade the proxy to the fixed GovImp and show the same attack is
+//      now blocked while normal operation keeps working (the "green" proof).
+//
+// The storage layout is IDENTICAL to GovImp (same AGov base, same trailing
+// state vars + __gap), which is what makes the proxy upgrade state-preserving.
+// Only the four fix sites differ from GovImp — they are marked "LEGACY:" below.
+// =============================================================================
 
-import "./interface/IBallotStorage.sol";
-import "./interface/IEnvStorage.sol";
-import "./interface/IStaking.sol";
+import "@openzeppelin/contracts-upgradeable/security/ReentrancyGuardUpgradeable.sol";
+import "../abstract/BallotEnums.sol";
+import "../abstract/EnvConstants.sol";
+import "../abstract/AGov.sol";
+
+import "../interface/IBallotStorage.sol";
+import "../interface/IEnvStorage.sol";
+import "../interface/IStaking.sol";
 
 import "@openzeppelin/contracts/proxy/utils/UUPSUpgradeable.sol";
 
-contract GovImp is AGov, ReentrancyGuardUpgradeable, BallotEnums, EnvConstants, UUPSUpgradeable {
+contract GovImpLegacy is AGov, ReentrancyGuardUpgradeable, BallotEnums, EnvConstants, UUPSUpgradeable {
     enum VariableTypes {
         Invalid,
         Int,
@@ -33,11 +50,9 @@ contract GovImp is AGov, ReentrancyGuardUpgradeable, BallotEnums, EnvConstants, 
     event MemberChanged(address indexed oldAddr, address indexed newAddr, address indexed newVoter);
     event EnvChanged(bytes32 envName, uint256 envType, bytes envVal);
     event MemberUpdated(address indexed addr, address indexed voter);
-    // added for case that ballot's result could not be applicable.
     event NotApplicable(uint256 indexed ballotId, string reason);
 
     event SetProposalTimePeriod(uint256 newPeriod);
-    // added for announced that migration gov data
     event GovDataMigrated(address indexed from);
 
     struct MemberInfo {
@@ -131,7 +146,6 @@ contract GovImp is AGov, ReentrancyGuardUpgradeable, BallotEnums, EnvConstants, 
         __Ownable_init();
         setRegistry(registry);
 
-        // _initialized = true;
         modifiedBlock = block.number;
 
         // Lock
@@ -139,8 +153,6 @@ contract GovImp is AGov, ReentrancyGuardUpgradeable, BallotEnums, EnvConstants, 
 
         require(lockAmount >= getMinStaking() && getMaxStaking() >= lockAmount, "Invalid lock amount");
 
-        // []{uint staker, uint voter, uint reward, bytes name, bytes enode, bytes ip, uint port}
-        // 32 bytes, 32 bytes, 32 bytes, [32 bytes, <data>] * 3, 32 bytes
         address staker;
         address voter;
         address reward;
@@ -219,7 +231,6 @@ contract GovImp is AGov, ReentrancyGuardUpgradeable, BallotEnums, EnvConstants, 
             node.enode = enode;
             node.ip = ip;
             node.port = port;
-            // checkNodeInfo[getNodeInfoHash(enode, ip, port)] = true;
             checkNodeName[name] = true;
             checkNodeEnode[enode] = true;
             checkNodeIpPort[keccak256(abi.encodePacked(ip, port))] = true;
@@ -231,7 +242,6 @@ contract GovImp is AGov, ReentrancyGuardUpgradeable, BallotEnums, EnvConstants, 
         nodeLength = idx;
     }
 
-    //Add member address = staker address = voter address
     function addProposalToAddMember(
         MemberInfo memory info
     ) external onlyGovMem checkTimePeriod checkLockedAmount checkMemberInfo(info) returns (uint256 ballotIdx) {
@@ -260,9 +270,8 @@ contract GovImp is AGov, ReentrancyGuardUpgradeable, BallotEnums, EnvConstants, 
         uint256 slashing
     ) external onlyGovMem checkTimePeriod checkLockedAmount returns (uint256 ballotIdx) {
         require(staker != ZERO, "Invalid address");
-        // W1G-04: target must be a real staker key, not a voter-only address (stakerIdx==0).
-        // Revert string kept as "Non-member" to preserve the existing external interface.
-        require(isStaker(staker), "Non-member");
+        // LEGACY (pre W1G-04): isMember admits voter-only addresses (stakerIdx==0).
+        require(isMember(staker), "Non-member");
         require(getMemberLength() > 1, "Cannot remove a sole member");
         require(lockedBalanceOf(staker) >= lockAmount, "Insufficient balance that can be unlocked.");
         ballotIdx = ballotLength + 1;
@@ -292,14 +301,6 @@ contract GovImp is AGov, ReentrancyGuardUpgradeable, BallotEnums, EnvConstants, 
         ballotLength = ballotIdx;
     }
 
-    // voter A, staker A -> voter B, staker B Ok with voting
-    // voter A, staker B -> voter C, staker C Ok with voting
-    // voter A, staker B -> voter A, staker A Ok with voting
-    // voter A call : voter A, staker A -> voter A, staker B X
-    // staker A call : voter A, staker A-> voter B, staker A Ok without voting
-    // only staker A call : voter B, staker A, reward C -> voter B, staker A, reward D Ok without voting only (voter can not change reward)
-    // staker only change own info
-    // voter can propose and vote anything
     function addProposalToChangeMember(
         MemberInfo memory newInfo,
         address oldStaker,
@@ -307,9 +308,8 @@ contract GovImp is AGov, ReentrancyGuardUpgradeable, BallotEnums, EnvConstants, 
         uint256 slashing
     ) external onlyGovMem checkTimePeriod checkLockedAmount checkMemberInfo(newInfo) returns (uint256 ballotIdx) {
         require(oldStaker != ZERO, "Invalid old Address");
-        // W1G-04: target must be a real staker key, not a voter-only address (stakerIdx==0).
-        // Revert string kept as "Non-member" to preserve the existing external interface.
-        require(isStaker(oldStaker), "Non-member");
+        // LEGACY (pre W1G-04): isMember admits voter-only addresses (stakerIdx==0).
+        require(isMember(oldStaker), "Non-member");
 
         require(
             (voters[stakerIdx[oldStaker]] == newInfo.voter ||
@@ -322,10 +322,8 @@ contract GovImp is AGov, ReentrancyGuardUpgradeable, BallotEnums, EnvConstants, 
         );
         // For exit
         if (msg.sender == oldStaker && oldStaker == newInfo.staker) {
-            // Change member enviroment, finalized
             require(unlockAmount == 0 && slashing == 0, "Invalid proposal");
         } else if (oldStaker != newInfo.staker /* && msg.sender != oldStaker */) {
-            // Propose Change or Exit member by other.
             require(unlockAmount + slashing <= getMinStaking(), "Invalid amount: (unlockAmount + slashing) must be equal or low to minStaking");
         }
 
@@ -341,7 +339,6 @@ contract GovImp is AGov, ReentrancyGuardUpgradeable, BallotEnums, EnvConstants, 
         updateBallotMemo(ballotIdx, newInfo.memo);
         createBallotForExit(ballotIdx, unlockAmount, slashing);
         ballotLength = ballotIdx;
-        // 요청자 == 변경할 voting 주소
         if (msg.sender == oldStaker && oldStaker == newInfo.staker) {
             (, , uint256 duration) = getBallotPeriod(ballotIdx);
             startBallot(ballotIdx, block.timestamp, block.timestamp + duration);
@@ -356,7 +353,6 @@ contract GovImp is AGov, ReentrancyGuardUpgradeable, BallotEnums, EnvConstants, 
     ) external onlyGovMem checkTimePeriod checkLockedAmount returns (uint256 ballotIdx) {
         require(newGovAddr != ZERO, "Implementation cannot be zero");
         require(newGovAddr != _getImplementation(), "Same contract address");
-        //check newGov has proxiableUUID
         try IERC1822Proxiable(newGovAddr).proxiableUUID() returns (bytes32 slot) {
             require(slot == _IMPLEMENTATION_SLOT, "ERC1967Upgrade: unsupported proxiableUUID");
         } catch {
@@ -381,7 +377,6 @@ contract GovImp is AGov, ReentrancyGuardUpgradeable, BallotEnums, EnvConstants, 
         bytes memory memo,
         uint256 duration
     ) external onlyGovMem checkTimePeriod checkLockedAmount returns (uint256 ballotIdx) {
-        // require(envName != 0, "Invalid name");
         require(uint256(VariableTypes.Int) <= envType && envType <= uint256(VariableTypes.String), "Invalid type");
         require(checkVariableCondition(envName, envVal), "Invalid value");
 
@@ -400,14 +395,10 @@ contract GovImp is AGov, ReentrancyGuardUpgradeable, BallotEnums, EnvConstants, 
     }
 
     function vote(uint256 ballotIdx, bool approval) external nonReentrant onlyGovMem checkLockedAmount {
-        // Check if some ballot is in progress
         require(checkUnfinalized(), "Expired");
 
-        // Check if the ballot can be voted
         uint256 ballotType = checkVotable(ballotIdx);
-        // Vote
         createVote(ballotIdx, approval);
-        // Finalize
         (, uint256 accept, uint256 reject) = getBallotVotingInfo(ballotIdx);
         uint256 threshold = getThreshold();
         if (accept >= threshold || reject >= threshold || (accept + reject) == 10000) {
@@ -441,16 +432,6 @@ contract GovImp is AGov, ReentrancyGuardUpgradeable, BallotEnums, EnvConstants, 
             (, uint256 endTime, ) = getBallotPeriod(ballotInVoting);
             if (state == uint256(BallotStates.InProgress)) {
                 if (endTime < block.timestamp) return false;
-                // require(endTime > block.timestamp, "Expired");
-                // require(ballotIdx == ballotInVoting, "Now in voting with different ballot");
-                // if (endTime < block.timestamp) {
-
-                //     finalizeBallot(ballotInVoting, uint256(BallotStates.Rejected));
-                //     ballotInVoting = 0;
-                //     // console.log("vote is finalized %s", ballotInVoting);
-                // } else if (ballotIdx != ballotInVoting) {
-                //     revert("Now in voting with different ballot");
-                // }
             }
         }
         return true;
@@ -476,10 +457,8 @@ contract GovImp is AGov, ReentrancyGuardUpgradeable, BallotEnums, EnvConstants, 
             }
             ballotInVoting = ballotIdx;
         } else if (state == uint256(BallotStates.InProgress)) {
-            // Nothing to do
             require(ballotIdx == ballotInVoting, "Now in voting with different ballot");
         } else {
-            // canceled
             revert("Expired");
         }
         return ballotType;
@@ -488,7 +467,7 @@ contract GovImp is AGov, ReentrancyGuardUpgradeable, BallotEnums, EnvConstants, 
     function createVote(uint256 ballotIdx, bool approval) private {
         uint256 voteIdx = voteLength + 1;
         address staker = getStakerAddr(msg.sender);
-        uint256 weight = 10000 / getMemberLength(); //IStaking(getStakingAddress()).calcVotingWeightWithScaleFactor(staker, 10000);
+        uint256 weight = 10000 / getMemberLength();
         uint256 decision = approval ? uint256(DecisionTypes.Accept) : uint256(DecisionTypes.Reject);
         IBallotStorage(getBallotStorageAddress()).createVote(voteIdx, ballotIdx, staker, decision, weight);
         voteLength = voteIdx;
@@ -542,12 +521,10 @@ contract GovImp is AGov, ReentrancyGuardUpgradeable, BallotEnums, EnvConstants, 
             uint256 lockAmount
         ) = getBallotMember(ballotIdx);
         if (isMember(newStaker)) {
-            // new staker is already a member or a voter/
             emit NotApplicable(ballotIdx, "Already a member");
             return false;
         }
         if (isReward(newReward)) {
-            // new staker is already a member or a voter/
             emit NotApplicable(ballotIdx, "Already a rewarder");
             return false;
         }
@@ -568,13 +545,7 @@ contract GovImp is AGov, ReentrancyGuardUpgradeable, BallotEnums, EnvConstants, 
             return false;
         }
 
-        // W1G-01: re-validate node uniqueness at execution time.
-        // Creation-time checkNodeInfoAdd does not protect against a second queued
-        // proposal carrying the same node metadata, since markers are only set here.
-        if (!checkNodeInfoAdd(name, enode, ip, port)) {
-            emit NotApplicable(ballotIdx, "Duplicated node info");
-            return false;
-        }
+        // LEGACY (pre W1G-01): NO execution-time node-uniqueness re-validation here.
 
         lock(newStaker, lockAmount);
 
@@ -595,7 +566,6 @@ contract GovImp is AGov, ReentrancyGuardUpgradeable, BallotEnums, EnvConstants, 
         node.enode = enode;
         node.ip = ip;
         node.port = port;
-        // checkNodeInfo[getNodeInfoHash(enode, ip, port)] = true;
         checkNodeName[name] = true;
         checkNodeEnode[enode] = true;
         checkNodeIpPort[keccak256(abi.encodePacked(ip, port))] = true;
@@ -617,17 +587,7 @@ contract GovImp is AGov, ReentrancyGuardUpgradeable, BallotEnums, EnvConstants, 
             emit NotApplicable(ballotIdx, "Not already a member");
             return; // Non-member. it is abnormal case, but passed
         }
-        // W1G-04: reject voter-only (index-0) identifiers before mutating member state.
-        if (stakerIdx[oldStaker] == 0 || nodeIdxFromMember[oldStaker] == 0) {
-            emit NotApplicable(ballotIdx, "Not already a member");
-            return;
-        }
-        // W1G-02: never let a stale ballot drop the member count to zero
-        // (creation enforces getMemberLength() > 1, re-check at execution).
-        if (getMemberLength() <= 1) {
-            emit NotApplicable(ballotIdx, "Cannot remove a sole member");
-            return;
-        }
+        // LEGACY (pre W1G-04 / W1G-02): no voter-only guard, no >1 re-check here.
 
         // Remove voting and reward member
         uint256 removeStakerIdx = stakerIdx[oldStaker];
@@ -639,23 +599,18 @@ contract GovImp is AGov, ReentrancyGuardUpgradeable, BallotEnums, EnvConstants, 
             stakers[removeStakerIdx] = endStaker;
             stakerIdx[endStaker] = removeStakerIdx;
 
-            // Reward can differ from oldStaker after a same-staker self-change.
-            // Remove reward through the actual reward key read from the removed index.
             uint256 removeRewardIdx = rewardIdx[oldReward];
             require(removeRewardIdx != 0, "Invalid reward index");
             address endReward = rewards[memberLength];
             rewards[removeRewardIdx] = endReward;
             rewardIdx[endReward] = removeRewardIdx;
 
-            // Voter can also differ from oldStaker after a same-staker self-change.
-            // Remove voter through the actual voter key read from the removed index.
             uint256 removeVoterIdx = voterIdx[oldVoter];
             require(removeVoterIdx != 0, "Invalid voter index");
             address endVoter = voters[memberLength];
             voters[removeVoterIdx] = endVoter;
             voterIdx[endVoter] = removeVoterIdx;
         }
-        // Clear the last element slot and remove the old mappings
         stakers[memberLength] = ZERO;
         stakerIdx[oldStaker] = 0;
 
@@ -668,8 +623,6 @@ contract GovImp is AGov, ReentrancyGuardUpgradeable, BallotEnums, EnvConstants, 
         memberLength = memberLength - 1;
 
         // Remove node
-        // The node index is independent from the staker, reward, and voter indexes.
-        // Bind the storage pointer only after loading the real node index.
         uint256 removeNodeIdx = nodeIdxFromMember[oldStaker];
         require(removeNodeIdx != 0, "Invalid node index");
         Node storage node = nodes[removeNodeIdx];
@@ -693,7 +646,6 @@ contract GovImp is AGov, ReentrancyGuardUpgradeable, BallotEnums, EnvConstants, 
         delete nodes[nodeLength];
         nodeLength = nodeLength - 1;
         modifiedBlock = block.number;
-        // Unlock and transfer remained to governance
         transferLockedAndUnlock(ballotIdx, oldStaker);
 
         emit MemberRemoved(oldStaker, oldVoter);
@@ -718,21 +670,16 @@ contract GovImp is AGov, ReentrancyGuardUpgradeable, BallotEnums, EnvConstants, 
 
         if (!isMember(oldStaker)) {
             emit NotApplicable(ballotIdx, "Old address is not a member");
-            return false; // Non-member. it is abnormal case.
-        }
-        // W1G-04: member must be identified by a real staker key; reject voter-only
-        // (index-0) addresses so changeMember never writes into the sentinel slot 0.
-        if (stakerIdx[oldStaker] == 0 || nodeIdxFromMember[oldStaker] == 0) {
-            emit NotApplicable(ballotIdx, "Old address is not a member");
             return false;
         }
+        // LEGACY (pre W1G-04): no voter-only (stakerIdx==0) guard here.
 
         //old staker
         uint256 memberIdx = stakerIdx[oldStaker];
         if (oldStaker != newStaker) {
             if (isMember(newStaker)) {
                 emit NotApplicable(ballotIdx, "new address is already a member");
-                return false; // already member. it is abnormal case.
+                return false;
             }
             if (newStaker != newVoter && newStaker != newReward) {
                 emit NotApplicable(ballotIdx, "Invalid voter address");
@@ -753,11 +700,7 @@ contract GovImp is AGov, ReentrancyGuardUpgradeable, BallotEnums, EnvConstants, 
         {
             Node memory node = nodes[nodeIdx];
 
-            if (
-                //if node info is not same
-                // node info can not duplicate
-                !checkNodeInfoChange(name, enode, ip, port, node)
-            ) {
+            if (!checkNodeInfoChange(name, enode, ip, port, node)) {
                 emit NotApplicable(ballotIdx, "Duplicated node info");
                 return false;
             }
@@ -780,9 +723,6 @@ contract GovImp is AGov, ReentrancyGuardUpgradeable, BallotEnums, EnvConstants, 
         return true;
     }
 
-    // isMember=> isStaker and isVoter
-    // vote => onlyVoter, staker can change voter without voting, default = staker == voter
-    // voter can change staker with voting.(changeMember)
     function changeMember(uint256 ballotIdx, bool self) private returns (bool) {
         if (!self) {
             fromValidBallot(ballotIdx, uint256(BallotTypes.MemberChange));
@@ -801,7 +741,7 @@ contract GovImp is AGov, ReentrancyGuardUpgradeable, BallotEnums, EnvConstants, 
         ) = getBallotMember(ballotIdx);
         if (!isMember(oldStaker)) {
             emit NotApplicable(ballotIdx, "Old address is not a member");
-            return false; // Non-member. it is abnormal case.
+            return false;
         }
 
         if (!checkChangeMember(ballotIdx, self, oldStaker, newStaker, newVoter, newReward, name, enode, ip, port, lockAmount)) return false;
@@ -809,7 +749,6 @@ contract GovImp is AGov, ReentrancyGuardUpgradeable, BallotEnums, EnvConstants, 
         //old staker
         uint256 memberIdx = stakerIdx[oldStaker];
         if (oldStaker != newStaker) {
-            // Change member
             stakers[memberIdx] = newStaker;
             stakerIdx[newStaker] = memberIdx;
             stakerIdx[oldStaker] = 0;
@@ -830,7 +769,6 @@ contract GovImp is AGov, ReentrancyGuardUpgradeable, BallotEnums, EnvConstants, 
             node.ip = ip;
             node.port = port;
             modifiedBlock = block.number;
-            // checkNodeInfo[getNodeInfoHash(enode, ip, port)] = true;
             checkNodeName[name] = true;
             checkNodeEnode[enode] = true;
             checkNodeIpPort[keccak256(abi.encodePacked(ip, port))] = true;
@@ -858,7 +796,6 @@ contract GovImp is AGov, ReentrancyGuardUpgradeable, BallotEnums, EnvConstants, 
             nodeIdxFromMember[newStaker] = nodeIdx;
             nodeIdxFromMember[oldStaker] = 0;
 
-            // Unlock and transfer remained to governance
             transferLockedAndUnlock(ballotIdx, oldStaker);
 
             emit MemberChanged(oldStaker, newStaker, newVoter);
@@ -891,7 +828,6 @@ contract GovImp is AGov, ReentrancyGuardUpgradeable, BallotEnums, EnvConstants, 
         emit EnvChanged(envKey, envType, envVal);
     }
 
-    //------------------ Code reduction for creation gas
     function createBallotForMember(uint256 id, uint256 bType, address creator, address oAddr, MemberInfo memory info) private {
         IBallotStorage(getBallotStorageAddress()).createBallotForMember(
             id, // ballot id
@@ -976,17 +912,12 @@ contract GovImp is AGov, ReentrancyGuardUpgradeable, BallotEnums, EnvConstants, 
     }
 
     function lockedBalanceOf(address addr) private view returns (uint256) {
-        // IStaking staking = IStaking(getStakingAddress()).lockedBalanceOf(addr);
         return IStaking(getStakingAddress()).lockedBalanceOf(addr);
     }
 
     function availableBalanceOf(address addr) private view returns (uint256) {
         return IStaking(getStakingAddress()).availableBalanceOf(addr);
     }
-
-    //------------------ Code reduction end
-
-    //====NXTMeta=====/
 
     function _authorizeUpgrade(address newImplementation) internal override onlyGovMem {}
 
@@ -1006,9 +937,6 @@ contract GovImp is AGov, ReentrancyGuardUpgradeable, BallotEnums, EnvConstants, 
     }
 
     function checkNodeInfoAdd(bytes memory name, bytes memory enode, bytes memory ip, uint port) internal view returns (bool check) {
-        //Enode can not be duplicated
-        //IP:port can not be duplicated
-        //Name can not be duplicated
         check = true;
         if (checkNodeEnode[enode]) check = false;
         if (checkNodeName[name]) check = false;
@@ -1024,9 +952,6 @@ contract GovImp is AGov, ReentrancyGuardUpgradeable, BallotEnums, EnvConstants, 
         uint port,
         Node memory nodeInfo
     ) internal view returns (bool check) {
-        //Enode can not be duplicated
-        //IP:port can not be duplicated
-        //Name can not be duplicated
         check = true;
         if ((keccak256(nodeInfo.enode) != keccak256(enode) && checkNodeEnode[enode])) check = false;
         if ((keccak256(nodeInfo.name) != keccak256(name) && checkNodeName[name])) check = false;
@@ -1038,25 +963,13 @@ contract GovImp is AGov, ReentrancyGuardUpgradeable, BallotEnums, EnvConstants, 
     uint256 public proposal_time_period;
     mapping(address => uint256) public lastAddProposalTime;
 
-    // //For a node duplicate check
-    // // testnet value is here
-    // // mapping(bytes32=>bool) internal checkNodeInfo;
-    // mapping(bytes=>bool) internal checkNodeName;
-    // mapping(bytes=>bool) internal checkNodeEnode;
-    // mapping(bytes32=>bool) internal checkNodeIpPort;
-
-    /**
-     * @dev This empty reserved space is put in place to allow future versions to add new
-     * variables without shifting down storage in the inheritance chain.
-     * See https://docs.openzeppelin.com/contracts/4.x/upgradeable#storage_gaps
-     */
     uint256[46] private __gap;
 
     function reInit() external reinitializer(2) onlyOwner {
         unchecked {
-            // W1G-03: node/member storage is 1-indexed; iterate 1..getMemberLength() inclusive
-            // so the last node is marked and the empty nodes[0] sentinel is never touched.
-            for (uint256 i = 1; i <= getMemberLength(); i++) {
+            // LEGACY (pre W1G-03): 0-indexed, exclusive upper bound. Marks the
+            // empty nodes[0] sentinel and skips the last real node nodes[N].
+            for (uint256 i = 0; i < getMemberLength(); i++) {
                 Node memory node = nodes[i];
                 checkNodeName[node.name] = true;
                 checkNodeEnode[node.enode] = true;
@@ -1079,7 +992,7 @@ contract GovImp is AGov, ReentrancyGuardUpgradeable, BallotEnums, EnvConstants, 
         __ReentrancyGuard_init();
         __Ownable_init();
 
-        GovImp ogov = GovImp(oldGov);
+        GovImpLegacy ogov = GovImpLegacy(oldGov);
         setRegistry(address(ogov.reg()));
         modifiedBlock = block.number;
         transferOwnership(ogov.owner());
@@ -1096,10 +1009,10 @@ contract GovImp is AGov, ReentrancyGuardUpgradeable, BallotEnums, EnvConstants, 
 
                 Node memory node;
                 (node.name, node.enode, node.ip, node.port) = ogov.getNode(i);
-                // W1G-03: validate against markers set by previously imported nodes.
-                // checkNodeInfoChange(.., node) compares the node to itself and always passes;
-                // checkNodeInfoAdd checks the markers directly so real duplicates are caught.
-                require(checkNodeInfoAdd(node.name, node.enode, node.ip, node.port), "node info is duplicated");
+                // LEGACY (pre W1G-03): dead check — checkNodeInfoChange(.., node)
+                // compares node to itself, so every field reads as "unchanged"
+                // and the function always returns true. Duplicates are NOT caught.
+                require(checkNodeInfoChange(node.name, node.enode, node.ip, node.port, node), "node info is duplicated");
                 checkNodeName[node.name] = true;
                 checkNodeEnode[node.enode] = true;
                 checkNodeIpPort[keccak256(abi.encodePacked(node.ip, node.port))] = true;
@@ -1119,8 +1032,6 @@ contract GovImp is AGov, ReentrancyGuardUpgradeable, BallotEnums, EnvConstants, 
 
         return 0;
     }
-
-    // Critical
 
     function upgradeTo(address) external override {
         revert("Invalid access");

--- a/wemix/governance-contract/contracts/mock/GovImpPreMarker.sol
+++ b/wemix/governance-contract/contracts/mock/GovImpPreMarker.sol
@@ -1,18 +1,32 @@
 // SPDX-License-Identifier: MIT
 pragma solidity ^0.8.0;
 
-import "@openzeppelin/contracts-upgradeable/security/ReentrancyGuardUpgradeable.sol";
-import "./abstract/BallotEnums.sol";
-import "./abstract/EnvConstants.sol";
-import "./abstract/AGov.sol";
+// =============================================================================
+// TEST-ONLY MOCK — DO NOT DEPLOY TO PRODUCTION.
+//
+// GovImpPreMarker models an EARLIER mainnet implementation that did NOT yet
+// maintain the node-uniqueness markers (checkNodeName/checkNodeEnode/
+// checkNodeIpPort). It is the historical state that reInit()'s marker-backfill
+// is meant to repair: init/initOnce/addMember DO NOT write markers (marked
+// "PREMARKER:" below). reInit() keeps the legacy off-by-one (0..N-1) loop so
+// the W1G-03 test can show the last node's marker is left unset.
+//
+// The storage layout is IDENTICAL to GovImp, so the proxy can be upgraded to
+// the fixed GovImp and have its (correct, 1..N) reInit run as the "green" path.
+// =============================================================================
 
-import "./interface/IBallotStorage.sol";
-import "./interface/IEnvStorage.sol";
-import "./interface/IStaking.sol";
+import "@openzeppelin/contracts-upgradeable/security/ReentrancyGuardUpgradeable.sol";
+import "../abstract/BallotEnums.sol";
+import "../abstract/EnvConstants.sol";
+import "../abstract/AGov.sol";
+
+import "../interface/IBallotStorage.sol";
+import "../interface/IEnvStorage.sol";
+import "../interface/IStaking.sol";
 
 import "@openzeppelin/contracts/proxy/utils/UUPSUpgradeable.sol";
 
-contract GovImp is AGov, ReentrancyGuardUpgradeable, BallotEnums, EnvConstants, UUPSUpgradeable {
+contract GovImpPreMarker is AGov, ReentrancyGuardUpgradeable, BallotEnums, EnvConstants, UUPSUpgradeable {
     enum VariableTypes {
         Invalid,
         Int,
@@ -33,11 +47,9 @@ contract GovImp is AGov, ReentrancyGuardUpgradeable, BallotEnums, EnvConstants, 
     event MemberChanged(address indexed oldAddr, address indexed newAddr, address indexed newVoter);
     event EnvChanged(bytes32 envName, uint256 envType, bytes envVal);
     event MemberUpdated(address indexed addr, address indexed voter);
-    // added for case that ballot's result could not be applicable.
     event NotApplicable(uint256 indexed ballotId, string reason);
 
     event SetProposalTimePeriod(uint256 newPeriod);
-    // added for announced that migration gov data
     event GovDataMigrated(address indexed from);
 
     struct MemberInfo {
@@ -114,10 +126,7 @@ contract GovImp is AGov, ReentrancyGuardUpgradeable, BallotEnums, EnvConstants, 
         node.enode = enode;
         node.ip = ip;
         node.port = port;
-        checkNodeName[name] = true;
-        checkNodeEnode[enode] = true;
-
-        checkNodeIpPort[keccak256(abi.encodePacked(ip, port))] = true;
+        // PREMARKER: markers intentionally NOT set here (pre-marker era).
 
         nodeIdxFromMember[msg.sender] = nodeLength;
         nodeToMember[nodeLength] = msg.sender;
@@ -131,7 +140,6 @@ contract GovImp is AGov, ReentrancyGuardUpgradeable, BallotEnums, EnvConstants, 
         __Ownable_init();
         setRegistry(registry);
 
-        // _initialized = true;
         modifiedBlock = block.number;
 
         // Lock
@@ -139,8 +147,6 @@ contract GovImp is AGov, ReentrancyGuardUpgradeable, BallotEnums, EnvConstants, 
 
         require(lockAmount >= getMinStaking() && getMaxStaking() >= lockAmount, "Invalid lock amount");
 
-        // []{uint staker, uint voter, uint reward, bytes name, bytes enode, bytes ip, uint port}
-        // 32 bytes, 32 bytes, 32 bytes, [32 bytes, <data>] * 3, 32 bytes
         address staker;
         address voter;
         address reward;
@@ -219,10 +225,7 @@ contract GovImp is AGov, ReentrancyGuardUpgradeable, BallotEnums, EnvConstants, 
             node.enode = enode;
             node.ip = ip;
             node.port = port;
-            // checkNodeInfo[getNodeInfoHash(enode, ip, port)] = true;
-            checkNodeName[name] = true;
-            checkNodeEnode[enode] = true;
-            checkNodeIpPort[keccak256(abi.encodePacked(ip, port))] = true;
+            // PREMARKER: markers intentionally NOT set here (pre-marker era).
 
             nodeToMember[idx] = staker;
             nodeIdxFromMember[staker] = idx;
@@ -231,7 +234,6 @@ contract GovImp is AGov, ReentrancyGuardUpgradeable, BallotEnums, EnvConstants, 
         nodeLength = idx;
     }
 
-    //Add member address = staker address = voter address
     function addProposalToAddMember(
         MemberInfo memory info
     ) external onlyGovMem checkTimePeriod checkLockedAmount checkMemberInfo(info) returns (uint256 ballotIdx) {
@@ -260,9 +262,8 @@ contract GovImp is AGov, ReentrancyGuardUpgradeable, BallotEnums, EnvConstants, 
         uint256 slashing
     ) external onlyGovMem checkTimePeriod checkLockedAmount returns (uint256 ballotIdx) {
         require(staker != ZERO, "Invalid address");
-        // W1G-04: target must be a real staker key, not a voter-only address (stakerIdx==0).
-        // Revert string kept as "Non-member" to preserve the existing external interface.
-        require(isStaker(staker), "Non-member");
+        // LEGACY (pre W1G-04): isMember admits voter-only addresses (stakerIdx==0).
+        require(isMember(staker), "Non-member");
         require(getMemberLength() > 1, "Cannot remove a sole member");
         require(lockedBalanceOf(staker) >= lockAmount, "Insufficient balance that can be unlocked.");
         ballotIdx = ballotLength + 1;
@@ -292,14 +293,6 @@ contract GovImp is AGov, ReentrancyGuardUpgradeable, BallotEnums, EnvConstants, 
         ballotLength = ballotIdx;
     }
 
-    // voter A, staker A -> voter B, staker B Ok with voting
-    // voter A, staker B -> voter C, staker C Ok with voting
-    // voter A, staker B -> voter A, staker A Ok with voting
-    // voter A call : voter A, staker A -> voter A, staker B X
-    // staker A call : voter A, staker A-> voter B, staker A Ok without voting
-    // only staker A call : voter B, staker A, reward C -> voter B, staker A, reward D Ok without voting only (voter can not change reward)
-    // staker only change own info
-    // voter can propose and vote anything
     function addProposalToChangeMember(
         MemberInfo memory newInfo,
         address oldStaker,
@@ -307,9 +300,8 @@ contract GovImp is AGov, ReentrancyGuardUpgradeable, BallotEnums, EnvConstants, 
         uint256 slashing
     ) external onlyGovMem checkTimePeriod checkLockedAmount checkMemberInfo(newInfo) returns (uint256 ballotIdx) {
         require(oldStaker != ZERO, "Invalid old Address");
-        // W1G-04: target must be a real staker key, not a voter-only address (stakerIdx==0).
-        // Revert string kept as "Non-member" to preserve the existing external interface.
-        require(isStaker(oldStaker), "Non-member");
+        // LEGACY (pre W1G-04): isMember admits voter-only addresses (stakerIdx==0).
+        require(isMember(oldStaker), "Non-member");
 
         require(
             (voters[stakerIdx[oldStaker]] == newInfo.voter ||
@@ -322,10 +314,8 @@ contract GovImp is AGov, ReentrancyGuardUpgradeable, BallotEnums, EnvConstants, 
         );
         // For exit
         if (msg.sender == oldStaker && oldStaker == newInfo.staker) {
-            // Change member enviroment, finalized
             require(unlockAmount == 0 && slashing == 0, "Invalid proposal");
         } else if (oldStaker != newInfo.staker /* && msg.sender != oldStaker */) {
-            // Propose Change or Exit member by other.
             require(unlockAmount + slashing <= getMinStaking(), "Invalid amount: (unlockAmount + slashing) must be equal or low to minStaking");
         }
 
@@ -341,7 +331,6 @@ contract GovImp is AGov, ReentrancyGuardUpgradeable, BallotEnums, EnvConstants, 
         updateBallotMemo(ballotIdx, newInfo.memo);
         createBallotForExit(ballotIdx, unlockAmount, slashing);
         ballotLength = ballotIdx;
-        // 요청자 == 변경할 voting 주소
         if (msg.sender == oldStaker && oldStaker == newInfo.staker) {
             (, , uint256 duration) = getBallotPeriod(ballotIdx);
             startBallot(ballotIdx, block.timestamp, block.timestamp + duration);
@@ -356,7 +345,6 @@ contract GovImp is AGov, ReentrancyGuardUpgradeable, BallotEnums, EnvConstants, 
     ) external onlyGovMem checkTimePeriod checkLockedAmount returns (uint256 ballotIdx) {
         require(newGovAddr != ZERO, "Implementation cannot be zero");
         require(newGovAddr != _getImplementation(), "Same contract address");
-        //check newGov has proxiableUUID
         try IERC1822Proxiable(newGovAddr).proxiableUUID() returns (bytes32 slot) {
             require(slot == _IMPLEMENTATION_SLOT, "ERC1967Upgrade: unsupported proxiableUUID");
         } catch {
@@ -381,7 +369,6 @@ contract GovImp is AGov, ReentrancyGuardUpgradeable, BallotEnums, EnvConstants, 
         bytes memory memo,
         uint256 duration
     ) external onlyGovMem checkTimePeriod checkLockedAmount returns (uint256 ballotIdx) {
-        // require(envName != 0, "Invalid name");
         require(uint256(VariableTypes.Int) <= envType && envType <= uint256(VariableTypes.String), "Invalid type");
         require(checkVariableCondition(envName, envVal), "Invalid value");
 
@@ -400,14 +387,10 @@ contract GovImp is AGov, ReentrancyGuardUpgradeable, BallotEnums, EnvConstants, 
     }
 
     function vote(uint256 ballotIdx, bool approval) external nonReentrant onlyGovMem checkLockedAmount {
-        // Check if some ballot is in progress
         require(checkUnfinalized(), "Expired");
 
-        // Check if the ballot can be voted
         uint256 ballotType = checkVotable(ballotIdx);
-        // Vote
         createVote(ballotIdx, approval);
-        // Finalize
         (, uint256 accept, uint256 reject) = getBallotVotingInfo(ballotIdx);
         uint256 threshold = getThreshold();
         if (accept >= threshold || reject >= threshold || (accept + reject) == 10000) {
@@ -441,16 +424,6 @@ contract GovImp is AGov, ReentrancyGuardUpgradeable, BallotEnums, EnvConstants, 
             (, uint256 endTime, ) = getBallotPeriod(ballotInVoting);
             if (state == uint256(BallotStates.InProgress)) {
                 if (endTime < block.timestamp) return false;
-                // require(endTime > block.timestamp, "Expired");
-                // require(ballotIdx == ballotInVoting, "Now in voting with different ballot");
-                // if (endTime < block.timestamp) {
-
-                //     finalizeBallot(ballotInVoting, uint256(BallotStates.Rejected));
-                //     ballotInVoting = 0;
-                //     // console.log("vote is finalized %s", ballotInVoting);
-                // } else if (ballotIdx != ballotInVoting) {
-                //     revert("Now in voting with different ballot");
-                // }
             }
         }
         return true;
@@ -476,10 +449,8 @@ contract GovImp is AGov, ReentrancyGuardUpgradeable, BallotEnums, EnvConstants, 
             }
             ballotInVoting = ballotIdx;
         } else if (state == uint256(BallotStates.InProgress)) {
-            // Nothing to do
             require(ballotIdx == ballotInVoting, "Now in voting with different ballot");
         } else {
-            // canceled
             revert("Expired");
         }
         return ballotType;
@@ -488,7 +459,7 @@ contract GovImp is AGov, ReentrancyGuardUpgradeable, BallotEnums, EnvConstants, 
     function createVote(uint256 ballotIdx, bool approval) private {
         uint256 voteIdx = voteLength + 1;
         address staker = getStakerAddr(msg.sender);
-        uint256 weight = 10000 / getMemberLength(); //IStaking(getStakingAddress()).calcVotingWeightWithScaleFactor(staker, 10000);
+        uint256 weight = 10000 / getMemberLength();
         uint256 decision = approval ? uint256(DecisionTypes.Accept) : uint256(DecisionTypes.Reject);
         IBallotStorage(getBallotStorageAddress()).createVote(voteIdx, ballotIdx, staker, decision, weight);
         voteLength = voteIdx;
@@ -542,12 +513,10 @@ contract GovImp is AGov, ReentrancyGuardUpgradeable, BallotEnums, EnvConstants, 
             uint256 lockAmount
         ) = getBallotMember(ballotIdx);
         if (isMember(newStaker)) {
-            // new staker is already a member or a voter/
             emit NotApplicable(ballotIdx, "Already a member");
             return false;
         }
         if (isReward(newReward)) {
-            // new staker is already a member or a voter/
             emit NotApplicable(ballotIdx, "Already a rewarder");
             return false;
         }
@@ -568,13 +537,7 @@ contract GovImp is AGov, ReentrancyGuardUpgradeable, BallotEnums, EnvConstants, 
             return false;
         }
 
-        // W1G-01: re-validate node uniqueness at execution time.
-        // Creation-time checkNodeInfoAdd does not protect against a second queued
-        // proposal carrying the same node metadata, since markers are only set here.
-        if (!checkNodeInfoAdd(name, enode, ip, port)) {
-            emit NotApplicable(ballotIdx, "Duplicated node info");
-            return false;
-        }
+        // LEGACY (pre W1G-01): NO execution-time node-uniqueness re-validation here.
 
         lock(newStaker, lockAmount);
 
@@ -595,10 +558,7 @@ contract GovImp is AGov, ReentrancyGuardUpgradeable, BallotEnums, EnvConstants, 
         node.enode = enode;
         node.ip = ip;
         node.port = port;
-        // checkNodeInfo[getNodeInfoHash(enode, ip, port)] = true;
-        checkNodeName[name] = true;
-        checkNodeEnode[enode] = true;
-        checkNodeIpPort[keccak256(abi.encodePacked(ip, port))] = true;
+        // PREMARKER: markers intentionally NOT set here (pre-marker era).
 
         nodeToMember[nNodeIdx] = newStaker;
         nodeIdxFromMember[newStaker] = nNodeIdx;
@@ -617,17 +577,7 @@ contract GovImp is AGov, ReentrancyGuardUpgradeable, BallotEnums, EnvConstants, 
             emit NotApplicable(ballotIdx, "Not already a member");
             return; // Non-member. it is abnormal case, but passed
         }
-        // W1G-04: reject voter-only (index-0) identifiers before mutating member state.
-        if (stakerIdx[oldStaker] == 0 || nodeIdxFromMember[oldStaker] == 0) {
-            emit NotApplicable(ballotIdx, "Not already a member");
-            return;
-        }
-        // W1G-02: never let a stale ballot drop the member count to zero
-        // (creation enforces getMemberLength() > 1, re-check at execution).
-        if (getMemberLength() <= 1) {
-            emit NotApplicable(ballotIdx, "Cannot remove a sole member");
-            return;
-        }
+        // LEGACY (pre W1G-04 / W1G-02): no voter-only guard, no >1 re-check here.
 
         // Remove voting and reward member
         uint256 removeStakerIdx = stakerIdx[oldStaker];
@@ -639,23 +589,18 @@ contract GovImp is AGov, ReentrancyGuardUpgradeable, BallotEnums, EnvConstants, 
             stakers[removeStakerIdx] = endStaker;
             stakerIdx[endStaker] = removeStakerIdx;
 
-            // Reward can differ from oldStaker after a same-staker self-change.
-            // Remove reward through the actual reward key read from the removed index.
             uint256 removeRewardIdx = rewardIdx[oldReward];
             require(removeRewardIdx != 0, "Invalid reward index");
             address endReward = rewards[memberLength];
             rewards[removeRewardIdx] = endReward;
             rewardIdx[endReward] = removeRewardIdx;
 
-            // Voter can also differ from oldStaker after a same-staker self-change.
-            // Remove voter through the actual voter key read from the removed index.
             uint256 removeVoterIdx = voterIdx[oldVoter];
             require(removeVoterIdx != 0, "Invalid voter index");
             address endVoter = voters[memberLength];
             voters[removeVoterIdx] = endVoter;
             voterIdx[endVoter] = removeVoterIdx;
         }
-        // Clear the last element slot and remove the old mappings
         stakers[memberLength] = ZERO;
         stakerIdx[oldStaker] = 0;
 
@@ -668,8 +613,6 @@ contract GovImp is AGov, ReentrancyGuardUpgradeable, BallotEnums, EnvConstants, 
         memberLength = memberLength - 1;
 
         // Remove node
-        // The node index is independent from the staker, reward, and voter indexes.
-        // Bind the storage pointer only after loading the real node index.
         uint256 removeNodeIdx = nodeIdxFromMember[oldStaker];
         require(removeNodeIdx != 0, "Invalid node index");
         Node storage node = nodes[removeNodeIdx];
@@ -693,7 +636,6 @@ contract GovImp is AGov, ReentrancyGuardUpgradeable, BallotEnums, EnvConstants, 
         delete nodes[nodeLength];
         nodeLength = nodeLength - 1;
         modifiedBlock = block.number;
-        // Unlock and transfer remained to governance
         transferLockedAndUnlock(ballotIdx, oldStaker);
 
         emit MemberRemoved(oldStaker, oldVoter);
@@ -718,21 +660,16 @@ contract GovImp is AGov, ReentrancyGuardUpgradeable, BallotEnums, EnvConstants, 
 
         if (!isMember(oldStaker)) {
             emit NotApplicable(ballotIdx, "Old address is not a member");
-            return false; // Non-member. it is abnormal case.
-        }
-        // W1G-04: member must be identified by a real staker key; reject voter-only
-        // (index-0) addresses so changeMember never writes into the sentinel slot 0.
-        if (stakerIdx[oldStaker] == 0 || nodeIdxFromMember[oldStaker] == 0) {
-            emit NotApplicable(ballotIdx, "Old address is not a member");
             return false;
         }
+        // LEGACY (pre W1G-04): no voter-only (stakerIdx==0) guard here.
 
         //old staker
         uint256 memberIdx = stakerIdx[oldStaker];
         if (oldStaker != newStaker) {
             if (isMember(newStaker)) {
                 emit NotApplicable(ballotIdx, "new address is already a member");
-                return false; // already member. it is abnormal case.
+                return false;
             }
             if (newStaker != newVoter && newStaker != newReward) {
                 emit NotApplicable(ballotIdx, "Invalid voter address");
@@ -753,11 +690,7 @@ contract GovImp is AGov, ReentrancyGuardUpgradeable, BallotEnums, EnvConstants, 
         {
             Node memory node = nodes[nodeIdx];
 
-            if (
-                //if node info is not same
-                // node info can not duplicate
-                !checkNodeInfoChange(name, enode, ip, port, node)
-            ) {
+            if (!checkNodeInfoChange(name, enode, ip, port, node)) {
                 emit NotApplicable(ballotIdx, "Duplicated node info");
                 return false;
             }
@@ -780,9 +713,6 @@ contract GovImp is AGov, ReentrancyGuardUpgradeable, BallotEnums, EnvConstants, 
         return true;
     }
 
-    // isMember=> isStaker and isVoter
-    // vote => onlyVoter, staker can change voter without voting, default = staker == voter
-    // voter can change staker with voting.(changeMember)
     function changeMember(uint256 ballotIdx, bool self) private returns (bool) {
         if (!self) {
             fromValidBallot(ballotIdx, uint256(BallotTypes.MemberChange));
@@ -801,7 +731,7 @@ contract GovImp is AGov, ReentrancyGuardUpgradeable, BallotEnums, EnvConstants, 
         ) = getBallotMember(ballotIdx);
         if (!isMember(oldStaker)) {
             emit NotApplicable(ballotIdx, "Old address is not a member");
-            return false; // Non-member. it is abnormal case.
+            return false;
         }
 
         if (!checkChangeMember(ballotIdx, self, oldStaker, newStaker, newVoter, newReward, name, enode, ip, port, lockAmount)) return false;
@@ -809,7 +739,6 @@ contract GovImp is AGov, ReentrancyGuardUpgradeable, BallotEnums, EnvConstants, 
         //old staker
         uint256 memberIdx = stakerIdx[oldStaker];
         if (oldStaker != newStaker) {
-            // Change member
             stakers[memberIdx] = newStaker;
             stakerIdx[newStaker] = memberIdx;
             stakerIdx[oldStaker] = 0;
@@ -830,7 +759,6 @@ contract GovImp is AGov, ReentrancyGuardUpgradeable, BallotEnums, EnvConstants, 
             node.ip = ip;
             node.port = port;
             modifiedBlock = block.number;
-            // checkNodeInfo[getNodeInfoHash(enode, ip, port)] = true;
             checkNodeName[name] = true;
             checkNodeEnode[enode] = true;
             checkNodeIpPort[keccak256(abi.encodePacked(ip, port))] = true;
@@ -858,7 +786,6 @@ contract GovImp is AGov, ReentrancyGuardUpgradeable, BallotEnums, EnvConstants, 
             nodeIdxFromMember[newStaker] = nodeIdx;
             nodeIdxFromMember[oldStaker] = 0;
 
-            // Unlock and transfer remained to governance
             transferLockedAndUnlock(ballotIdx, oldStaker);
 
             emit MemberChanged(oldStaker, newStaker, newVoter);
@@ -891,7 +818,6 @@ contract GovImp is AGov, ReentrancyGuardUpgradeable, BallotEnums, EnvConstants, 
         emit EnvChanged(envKey, envType, envVal);
     }
 
-    //------------------ Code reduction for creation gas
     function createBallotForMember(uint256 id, uint256 bType, address creator, address oAddr, MemberInfo memory info) private {
         IBallotStorage(getBallotStorageAddress()).createBallotForMember(
             id, // ballot id
@@ -976,17 +902,12 @@ contract GovImp is AGov, ReentrancyGuardUpgradeable, BallotEnums, EnvConstants, 
     }
 
     function lockedBalanceOf(address addr) private view returns (uint256) {
-        // IStaking staking = IStaking(getStakingAddress()).lockedBalanceOf(addr);
         return IStaking(getStakingAddress()).lockedBalanceOf(addr);
     }
 
     function availableBalanceOf(address addr) private view returns (uint256) {
         return IStaking(getStakingAddress()).availableBalanceOf(addr);
     }
-
-    //------------------ Code reduction end
-
-    //====NXTMeta=====/
 
     function _authorizeUpgrade(address newImplementation) internal override onlyGovMem {}
 
@@ -1006,9 +927,6 @@ contract GovImp is AGov, ReentrancyGuardUpgradeable, BallotEnums, EnvConstants, 
     }
 
     function checkNodeInfoAdd(bytes memory name, bytes memory enode, bytes memory ip, uint port) internal view returns (bool check) {
-        //Enode can not be duplicated
-        //IP:port can not be duplicated
-        //Name can not be duplicated
         check = true;
         if (checkNodeEnode[enode]) check = false;
         if (checkNodeName[name]) check = false;
@@ -1024,9 +942,6 @@ contract GovImp is AGov, ReentrancyGuardUpgradeable, BallotEnums, EnvConstants, 
         uint port,
         Node memory nodeInfo
     ) internal view returns (bool check) {
-        //Enode can not be duplicated
-        //IP:port can not be duplicated
-        //Name can not be duplicated
         check = true;
         if ((keccak256(nodeInfo.enode) != keccak256(enode) && checkNodeEnode[enode])) check = false;
         if ((keccak256(nodeInfo.name) != keccak256(name) && checkNodeName[name])) check = false;
@@ -1038,25 +953,13 @@ contract GovImp is AGov, ReentrancyGuardUpgradeable, BallotEnums, EnvConstants, 
     uint256 public proposal_time_period;
     mapping(address => uint256) public lastAddProposalTime;
 
-    // //For a node duplicate check
-    // // testnet value is here
-    // // mapping(bytes32=>bool) internal checkNodeInfo;
-    // mapping(bytes=>bool) internal checkNodeName;
-    // mapping(bytes=>bool) internal checkNodeEnode;
-    // mapping(bytes32=>bool) internal checkNodeIpPort;
-
-    /**
-     * @dev This empty reserved space is put in place to allow future versions to add new
-     * variables without shifting down storage in the inheritance chain.
-     * See https://docs.openzeppelin.com/contracts/4.x/upgradeable#storage_gaps
-     */
     uint256[46] private __gap;
 
     function reInit() external reinitializer(2) onlyOwner {
         unchecked {
-            // W1G-03: node/member storage is 1-indexed; iterate 1..getMemberLength() inclusive
-            // so the last node is marked and the empty nodes[0] sentinel is never touched.
-            for (uint256 i = 1; i <= getMemberLength(); i++) {
+            // LEGACY (pre W1G-03): 0-indexed, exclusive upper bound. Marks the
+            // empty nodes[0] sentinel and skips the last real node nodes[N].
+            for (uint256 i = 0; i < getMemberLength(); i++) {
                 Node memory node = nodes[i];
                 checkNodeName[node.name] = true;
                 checkNodeEnode[node.enode] = true;
@@ -1079,7 +982,7 @@ contract GovImp is AGov, ReentrancyGuardUpgradeable, BallotEnums, EnvConstants, 
         __ReentrancyGuard_init();
         __Ownable_init();
 
-        GovImp ogov = GovImp(oldGov);
+        GovImpPreMarker ogov = GovImpPreMarker(oldGov);
         setRegistry(address(ogov.reg()));
         modifiedBlock = block.number;
         transferOwnership(ogov.owner());
@@ -1096,10 +999,10 @@ contract GovImp is AGov, ReentrancyGuardUpgradeable, BallotEnums, EnvConstants, 
 
                 Node memory node;
                 (node.name, node.enode, node.ip, node.port) = ogov.getNode(i);
-                // W1G-03: validate against markers set by previously imported nodes.
-                // checkNodeInfoChange(.., node) compares the node to itself and always passes;
-                // checkNodeInfoAdd checks the markers directly so real duplicates are caught.
-                require(checkNodeInfoAdd(node.name, node.enode, node.ip, node.port), "node info is duplicated");
+                // LEGACY (pre W1G-03): dead check — checkNodeInfoChange(.., node)
+                // compares node to itself, so every field reads as "unchanged"
+                // and the function always returns true. Duplicates are NOT caught.
+                require(checkNodeInfoChange(node.name, node.enode, node.ip, node.port, node), "node info is duplicated");
                 checkNodeName[node.name] = true;
                 checkNodeEnode[node.enode] = true;
                 checkNodeIpPort[keccak256(abi.encodePacked(node.ip, node.port))] = true;
@@ -1119,8 +1022,6 @@ contract GovImp is AGov, ReentrancyGuardUpgradeable, BallotEnums, EnvConstants, 
 
         return 0;
     }
-
-    // Critical
 
     function upgradeTo(address) external override {
         revert("Invalid access");

--- a/wemix/governance-contract/test/contracts.go
+++ b/wemix/governance-contract/test/contracts.go
@@ -62,12 +62,32 @@ func NewGovernance(t *testing.T) *Governance {
 	}
 }
 
+// DeployContracts deploys the full governance stack with the production GovImp
+// as the initial implementation behind the Gov proxy.
 func (g *Governance) DeployContracts(t *testing.T) *Governance {
+	return g.deployContracts(t, compiled.GovImp)
+}
+
+// DeployContractsLegacy deploys the same stack but with the UNFIXED GovImpLegacy
+// mock as the initial implementation, so a test can build a pre-fix ledger and
+// then upgrade the proxy to the fixed GovImp (see upgradeGovImpl).
+func (g *Governance) DeployContractsLegacy(t *testing.T) *Governance {
+	return g.deployContracts(t, compiled.GovImpLegacy)
+}
+
+// DeployContractsPreMarker deploys the stack with the GovImpPreMarker mock
+// (unfixed AND not maintaining node-uniqueness markers) as the initial impl,
+// used to give W1G-03's reInit off-by-one observable teeth.
+func (g *Governance) DeployContractsPreMarker(t *testing.T) *Governance {
+	return g.deployContracts(t, compiled.GovImpPreMarker)
+}
+
+func (g *Governance) deployContracts(t *testing.T, govImpl *bindContract) *Governance {
 	// deploy registry
 	registry, Registry, err := g.Deploy(compiled.Registry.Deploy(g.backend, g.owner))
 	require.NoError(t, err)
-	// deploy impls
-	govImp, _, err := g.Deploy(compiled.GovImp.Deploy(g.backend, g.owner))
+	// deploy impls (the gov implementation is selectable: production or a mock)
+	govImp, _, err := g.Deploy(govImpl.Deploy(g.backend, g.owner))
 	require.NoError(t, err)
 	ncpExitImp, _, err := g.Deploy(compiled.NCPExitImp.Deploy(g.backend, g.owner))
 	require.NoError(t, err)
@@ -239,6 +259,7 @@ func init() {
 type compiledContract struct {
 	Registry,
 	Gov, GovImp,
+	GovImpLegacy, GovImpPreMarker, // test-only mocks (contracts/mock)
 	NCPExit, NCPExitImp,
 	Staking, StakingImp,
 	BallotStorage, BallotStorageImp,
@@ -250,6 +271,8 @@ func (c *compiledContract) Compile(root string) {
 		filepath.Join(root, "Registry.sol"),
 		filepath.Join(root, "Gov.sol"),
 		filepath.Join(root, "GovImp.sol"),
+		filepath.Join(root, "mock", "GovImpLegacy.sol"),
+		filepath.Join(root, "mock", "GovImpPreMarker.sol"),
 		filepath.Join(root, "NCPExit.sol"),
 		filepath.Join(root, "NCPExitImp.sol"),
 		filepath.Join(root, "Staking.sol"),
@@ -266,6 +289,10 @@ func (c *compiledContract) Compile(root string) {
 		} else if c.Gov, err = newBindContract(contracts["Gov"]); err != nil {
 			panic(err)
 		} else if c.GovImp, err = newBindContract(contracts["GovImp"]); err != nil {
+			panic(err)
+		} else if c.GovImpLegacy, err = newBindContract(contracts["GovImpLegacy"]); err != nil {
+			panic(err)
+		} else if c.GovImpPreMarker, err = newBindContract(contracts["GovImpPreMarker"]); err != nil {
 			panic(err)
 		} else if c.NCPExit, err = newBindContract(contracts["NCPExit"]); err != nil {
 			panic(err)

--- a/wemix/governance-contract/test/gov_test.go
+++ b/wemix/governance-contract/test/gov_test.go
@@ -3710,7 +3710,7 @@ func TestW1G02_Legacy_EmptyGovernance_RedThenGreen(t *testing.T) {
 // that already holds duplicate node metadata, which the uniqueness-enforcing
 // contracts cannot produce; that case needs a mock legacy and is out of scope here.
 func TestW1G03_MigrateFromLegacyIntegrity(t *testing.T) {
-	gov := NewGovernance(t).DeployContracts(t) // legacy gov, owner = member 1
+	gov := NewGovernance(t).DeployContractsLegacy(t) // legacy gov, owner = member 1
 	owner := gov.owner
 	B := getTxOpt(t, "w1g03_mig_B")
 	nodeB := nodeInfo{[]byte("w1g03m-B"), w1gEnode("12121212"), []byte("127.0.0.31"), big.NewInt(8542)}
@@ -3749,8 +3749,12 @@ func TestW1G03_MigrateFromLegacyIntegrity(t *testing.T) {
 //
 // Teeth limitation: the 1..N (vs buggy 0..N-1) loop only changes observable
 // behaviour when markers start empty (a pre-marker in-place upgrade). In a fresh
-// deploy addMember already sets markers, so this test confirms reInit runs and
-// does not corrupt uniqueness; the off-by-one's teeth need a pre-marker fixture.
+// deploy addMember already sets markers, so even a buggy 0-indexed reInit that
+// skips the last node leaves that node's marker set — this test alone cannot
+// distinguish the buggy reInit from the fixed one. It is therefore a smoke test
+// (reInit runs and does not corrupt uniqueness on a fresh deploy); the
+// off-by-one's actual teeth live in TestW1G03_PreMarker_ReInitOffByOne_RedThenGreen,
+// which uses the GovImpPreMarker fixture (empty markers) to make the skip observable.
 func TestW1G03_ReInitPreservesNodeUniqueness(t *testing.T) {
 	gov := NewGovernance(t).DeployContracts(t)
 	owner := gov.owner
@@ -3761,7 +3765,7 @@ func TestW1G03_ReInitPreservesNodeUniqueness(t *testing.T) {
 	infoB := w1gInfo(B.From, B.From, B.From, nodeB, "add B")
 	require.NoError(t, gov.ExpectedOk(gov.GovImp.Transact(owner, "addProposalToAddMember", infoB)))
 	require.NoError(t, gov.ExpectedOk(gov.GovImp.Transact(owner, "vote", getBallotIdx(t, gov), true)))
-	require.Equal(t, int64(2), w1gMemberLength(t, gov)) // owner is the last node here
+	require.Equal(t, int64(2), w1gMemberLength(t, gov)) // B is the last node here (index 2)
 
 	// reInit (reinitializer(2), owner-only) must not revert
 	require.NoError(t, gov.ExpectedOk(gov.GovImp.Transact(owner, "reInit")))
@@ -3856,7 +3860,7 @@ func TestW1G03_Legacy_MigrateDeadCheck_RedThenGreen(t *testing.T) {
 // legacy gov must survive migration with all three index maps still pointing at
 // the same slot. This exercises the migrate path (distinct from the changeGov
 // upgrade path) on a separated ledger — the "ledger preservation" concern of
-// 검증 2 — using the fixed migrateFromLegacy on a clean (non-duplicate) source.
+// Check 2 — using the fixed migrateFromLegacy on a clean (non-duplicate) source.
 // ============================================================================
 func TestW1G03_Legacy_MigratePreservesSeparation(t *testing.T) {
 	gov := NewGovernance(t).DeployContractsLegacy(t)
@@ -4246,7 +4250,7 @@ func TestW1G04_Legacy_Slot0Poison_RedThenGreen(t *testing.T) {
 // ==========================================================================
 
 // ============================================================================
-// 검증 2 / 3 / 5 — Legacy ledger -> upgrade -> exercise EVERY core flow.
+// Checks 2 / 3 / 5 — Legacy ledger -> upgrade -> exercise EVERY core flow.
 //
 // Builds a 3-member legacy ledger where member B has a self-separated
 // staker/voter/reward, upgrades the proxy to the fixed GovImp, then drives
@@ -4313,7 +4317,7 @@ func TestW1G_LegacyUpgrade_FullLifecycle(t *testing.T) {
 	require.Equal(t, int64(4), w1gMemberLength(t, gov))
 
 	// ====================================================================
-	// FLOW 2 — 검증 5: oldStaker identification on the FIXED contract.
+	// FLOW 2 — Check 5: oldStaker identification on the FIXED contract.
 	//   (a) passing the separated VOTER address Bv as oldStaker -> "Non-member"
 	//   (b) passing the real STAKER address B as oldStaker -> OK (self-update)
 	// ====================================================================
@@ -4376,7 +4380,7 @@ func TestW1G_LegacyUpgrade_FullLifecycle(t *testing.T) {
 }
 
 // ============================================================================
-// 검증 2 보강 — voter-driven ENV and GOV proposals.
+// Check 2 (supplement) — voter-driven ENV and GOV proposals.
 //
 // Complements the FullLifecycle test (where the separated voter drives add /
 // change / remove). Here the separated voter key Bv ALSO proposes — and helps

--- a/wemix/governance-contract/test/gov_test.go
+++ b/wemix/governance-contract/test/gov_test.go
@@ -3273,6 +3273,10 @@ func TestGov_IndexCorruptionAfterRemoveMember(t *testing.T) {
 	checkGovMember(t, gov, targetIdx, memberC_info)
 }
 
+// ==========================================================================
+// Shared test helpers (ledger assertions, ballot voting, legacy-upgrade driver)
+// ==========================================================================
+
 func checkGovMember(t *testing.T, gov *Governance, idx *big.Int, info MemberInfo) {
 	var callOpts = new(bind.CallOpts)
 
@@ -3317,13 +3321,1109 @@ func checkGovMember(t *testing.T, gov *Governance, idx *big.Int, info MemberInfo
 	require.Equal(t, info.Ip, ip)
 	require.True(t, info.Port.Cmp(port) == 0)
 }
+
 func getMemberIdx(t *testing.T, gov *Governance, staker common.Address) *big.Int {
 	var idx *big.Int
 	require.NoError(t, gov.GovImp.Call(new(bind.CallOpts), &[]interface{}{&idx}, "stakerIdx", staker))
 	return idx
 }
+
 func getBallotIdx(t *testing.T, gov *Governance) *big.Int {
 	var length *big.Int
 	require.NoError(t, gov.GovImp.Call(new(bind.CallOpts), &[]interface{}{&length}, "ballotLength"))
 	return length
+}
+
+// enode helper: 64-byte enodes that only differ in their first byte so each
+// scenario node is unique by name/enode/ip while staying a valid 64-byte value.
+func w1gEnode(prefix string) []byte {
+	const rest = "4311c39f35f516fa664deaaaa13e85b2f7493f37f6144d86991ec012937307647bd3b9a82abe2974e1407241d54947bbb39763a4cac9f77166ad92a0"
+	return hexutil.MustDecode("0x" + prefix + rest)
+}
+
+func w1gFundAndStake(t *testing.T, gov *Governance, opt *bind.TransactOpts) {
+	require.NoError(t, gov.ExpectedOk(TransferCoin(gov.backend, gov.owner, towei(2_000_000), &opt.From)))
+	opt.Value = LOCK_AMOUNT
+	require.NoError(t, gov.ExpectedOk(gov.StakingImp.Transact(opt, "deposit")))
+	opt.Value = nil
+}
+
+func w1gInfo(staker, voter, reward common.Address, node nodeInfo, memo string) MemberInfo {
+	return MemberInfo{
+		Staker: staker, Voter: voter, Reward: reward,
+		Name: node.name, Enode: node.enode, Ip: node.ip, Port: node.port,
+		LockAmount: LOCK_AMOUNT, Memo: []byte(memo), Duration: big.NewInt(86400),
+	}
+}
+
+func w1gBool(t *testing.T, gov *Governance, method string, arg common.Address) bool {
+	var b bool
+	require.NoError(t, gov.GovImp.Call(new(bind.CallOpts), &[]interface{}{&b}, method, arg))
+	return b
+}
+
+func w1gMemberLength(t *testing.T, gov *Governance) int64 {
+	var n *big.Int
+	require.NoError(t, gov.GovImp.Call(new(bind.CallOpts), &[]interface{}{&n}, "getMemberLength"))
+	return n.Int64()
+}
+
+func w1gStakerAddr(t *testing.T, gov *Governance, a common.Address) common.Address {
+	var out common.Address
+	require.NoError(t, gov.GovImp.Call(new(bind.CallOpts), &[]interface{}{&out}, "getStakerAddr", a))
+	return out
+}
+
+// like checkGovMember but against an arbitrary bound GovImp (used for the
+// migrated proxy in the W1G-03 migration test).
+func w1gCheckMemberOn(t *testing.T, bc *bind.BoundContract, idx *big.Int, info MemberInfo) {
+	callOpts := new(bind.CallOpts)
+	var stakerIdx, voterIdx, rewardIdx, nodeIdx *big.Int
+	require.NoError(t, bc.Call(callOpts, &[]interface{}{&stakerIdx}, "stakerIdx", info.Staker))
+	require.NoError(t, bc.Call(callOpts, &[]interface{}{&voterIdx}, "voterIdx", info.Voter))
+	require.NoError(t, bc.Call(callOpts, &[]interface{}{&rewardIdx}, "rewardIdx", info.Reward))
+	require.NoError(t, bc.Call(callOpts, &[]interface{}{&nodeIdx}, "getNodeIdxFromMember", info.Staker))
+	require.Equal(t, 0, idx.Cmp(stakerIdx))
+	require.Equal(t, 0, idx.Cmp(voterIdx))
+	require.Equal(t, 0, idx.Cmp(rewardIdx))
+	require.Equal(t, 0, idx.Cmp(nodeIdx))
+
+	var staker, voter, reward common.Address
+	require.NoError(t, bc.Call(callOpts, &[]interface{}{&staker}, "getMember", idx))
+	require.NoError(t, bc.Call(callOpts, &[]interface{}{&voter}, "getVoter", idx))
+	require.NoError(t, bc.Call(callOpts, &[]interface{}{&reward}, "getReward", idx))
+	require.Equal(t, info.Staker, staker)
+	require.Equal(t, info.Voter, voter)
+	require.Equal(t, info.Reward, reward)
+
+	getNode := []interface{}{}
+	require.NoError(t, bc.Call(callOpts, &getNode, "getNode", idx))
+	require.Len(t, getNode, 4)
+	require.Equal(t, info.Name, getNode[0].([]byte))
+	require.Equal(t, info.Enode, getNode[1].([]byte))
+	require.Equal(t, info.Ip, getNode[2].([]byte))
+	require.Equal(t, 0, info.Port.Cmp(getNode[3].(*big.Int)))
+}
+
+// ballotFinalized reads BallotStorage.getBallotState(ballotIdx) and returns its
+// isFinalized flag (index 2 of the tuple).
+func ballotFinalized(t *testing.T, gov *Governance, ballotIdx *big.Int) bool {
+	state := []interface{}{}
+	require.NoError(t, gov.BallotStorageImp.Call(new(bind.CallOpts), &state, "getBallotState", ballotIdx))
+	require.Len(t, state, 3)
+	return state[2].(bool)
+}
+
+// voteAccept casts an approval vote from each given voter in turn and stops as
+// soon as the ballot finalizes (threshold reached). It asserts the ballot is
+// finalized at the end. It does NOT assert acceptance — callers verify the
+// concrete effect (member added / removed / impl changed) themselves, because
+// a finalized ballot may legitimately end Rejected (e.g. NotApplicable).
+func voteAccept(t *testing.T, gov *Governance, ballotIdx *big.Int, voters ...*bind.TransactOpts) {
+	for _, v := range voters {
+		if ballotFinalized(t, gov, ballotIdx) {
+			break
+		}
+		require.NoError(t, gov.ExpectedOk(gov.GovImp.Transact(v, "vote", ballotIdx, true)))
+	}
+	require.True(t, ballotFinalized(t, gov, ballotIdx), "ballot %s did not finalize", ballotIdx)
+}
+
+// govImplementation returns the implementation address the Gov proxy delegates
+// to right now.
+func govImplementation(t *testing.T, gov *Governance) common.Address {
+	var imp common.Address
+	require.NoError(t, gov.Gov.Call(new(bind.CallOpts), &[]interface{}{&imp}, "implementation"))
+	return imp
+}
+
+// upgradeGovToFixed deploys the production GovImp, drives a GovernanceChange
+// ballot through `proposer` + `voters` until the proxy points at the fixed
+// impl, then runs reInit (owner-only, reinitializer(2)). This is the real
+// mainnet upgrade path. Returns the new (fixed) implementation address.
+func upgradeGovToFixed(t *testing.T, gov *Governance, proposer *bind.TransactOpts, voters ...*bind.TransactOpts) common.Address {
+	fixedImp, _, err := gov.Deploy(compiled.GovImp.Deploy(gov.backend, gov.owner))
+	require.NoError(t, err)
+	require.NotEqual(t, govImplementation(t, gov), fixedImp)
+
+	require.NoError(t, gov.ExpectedOk(gov.GovImp.Transact(
+		proposer, "addProposalToChangeGov", fixedImp, []byte("upgrade to fixed GovImp"), big.NewInt(86400))))
+	ballot := getBallotIdx(t, gov)
+	for _, v := range voters {
+		if govImplementation(t, gov) == fixedImp {
+			break
+		}
+		require.NoError(t, gov.ExpectedOk(gov.GovImp.Transact(v, "vote", ballot, true)))
+	}
+	require.Equal(t, fixedImp, govImplementation(t, gov), "proxy did not upgrade to fixed impl")
+
+	// reInit backfills node-uniqueness markers (1..N) on the now-fixed impl.
+	require.NoError(t, gov.ExpectedOk(gov.GovImp.Transact(gov.owner, "reInit")))
+	return fixedImp
+}
+
+// getNodeEnode returns the enode bytes stored for member index idx.
+func getNodeEnode(t *testing.T, gov *Governance, idx *big.Int) []byte {
+	out := []interface{}{}
+	require.NoError(t, gov.GovImp.Call(new(bind.CallOpts), &out, "getNode", idx))
+	require.Len(t, out, 4)
+	return out[1].([]byte)
+}
+
+func getVoterAt(t *testing.T, gov *Governance, idx *big.Int) common.Address {
+	var v common.Address
+	require.NoError(t, gov.GovImp.Call(new(bind.CallOpts), &[]interface{}{&v}, "getVoter", idx))
+	return v
+}
+
+// addPlainMember registers a staker==voter==reward member through the normal
+// propose+vote path and returns its member index. `voters` must reach quorum.
+func addPlainMember(t *testing.T, gov *Governance, proposer, member *bind.TransactOpts, node nodeInfo, memo string, voters ...*bind.TransactOpts) *big.Int {
+	w1gFundAndStake(t, gov, member)
+	info := w1gInfo(member.From, member.From, member.From, node, memo)
+	require.NoError(t, gov.ExpectedOk(gov.GovImp.Transact(proposer, "addProposalToAddMember", info)))
+	voteAccept(t, gov, getBallotIdx(t, gov), voters...)
+	idx := getMemberIdx(t, gov, member.From)
+	require.True(t, w1gBool(t, gov, "isStaker", member.From))
+	return idx
+}
+
+// ==========================================================================
+// W1G-01 — duplicate node uniqueness at execution
+// ==========================================================================
+
+// W1G-01: two add-member proposals carrying the SAME node metadata are both
+// queued (creation check passes because markers are only set at execution).
+// After the first is applied, the second must be rejected at execution so no
+// duplicate validator identity is written.
+func TestW1G01_DuplicateNodeRejectedAtExecution(t *testing.T) {
+	gov := NewGovernance(t).DeployContracts(t)
+	owner := gov.owner
+	C := getTxOpt(t, "w1g01_C")
+	D := getTxOpt(t, "w1g01_D")
+	dupNode := nodeInfo{[]byte("w1g01-dup"), w1gEnode("aaaaaaaa"), []byte("10.0.0.50"), big.NewInt(8542)}
+
+	w1gFundAndStake(t, gov, C)
+	w1gFundAndStake(t, gov, D)
+
+	infoC := w1gInfo(C.From, C.From, C.From, dupNode, "C dup")
+	infoD := w1gInfo(D.From, D.From, D.From, dupNode, "D dup") // identical node metadata
+
+	// queue BOTH proposals before either executes -> both pass creation-time check
+	require.NoError(t, gov.ExpectedOk(gov.GovImp.Transact(owner, "addProposalToAddMember", infoC)))
+	ballotC := getBallotIdx(t, gov)
+	require.NoError(t, gov.ExpectedOk(gov.GovImp.Transact(owner, "addProposalToAddMember", infoD)))
+	ballotD := getBallotIdx(t, gov)
+
+	// apply C (owner is sole member, weight 10000) -> C added, node markers set
+	require.NoError(t, gov.ExpectedOk(gov.GovImp.Transact(owner, "vote", ballotC, true)))
+	cIdx := getMemberIdx(t, gov, C.From)
+	checkGovMember(t, gov, cIdx, infoC)
+	require.Equal(t, int64(2), w1gMemberLength(t, gov))
+
+	// apply D with the SAME node: members={owner,C} (2) -> both must vote
+	require.NoError(t, gov.ExpectedOk(gov.GovImp.Transact(owner, "vote", ballotD, true)))
+	require.NoError(t, gov.ExpectedOk(gov.GovImp.Transact(C, "vote", ballotD, true)))
+
+	// W1G-01: addMember re-validates node uniqueness -> D rejected, NOT added
+	require.False(t, w1gBool(t, gov, "isStaker", D.From))
+	require.Equal(t, int64(2), w1gMemberLength(t, gov))
+}
+
+// ============================================================================
+// W1G-01 — duplicate node at execution.  RED on legacy, GREEN after upgrade.
+//
+// Two add-member proposals carry the SAME node metadata. Both pass the
+// creation-time check (markers are only set at execution). On LEGACY the second
+// addMember writes the duplicate node anyway. After upgrade the queued second
+// proposal is re-validated at execution and rejected (NotApplicable).
+// ============================================================================
+func TestW1G01_Legacy_DuplicateNode_RedThenGreen(t *testing.T) {
+	dupNode := nodeInfo{[]byte("w01-dup"), w1gEnode("01010101"), []byte("10.1.9.9"), big.NewInt(8542)}
+
+	t.Run("RED_legacy", func(t *testing.T) {
+		gov := NewGovernance(t).DeployContractsLegacy(t)
+		owner := gov.owner
+		C := getTxOpt(t, "w01_C")
+		D := getTxOpt(t, "w01_D")
+		w1gFundAndStake(t, gov, C)
+		w1gFundAndStake(t, gov, D)
+
+		// queue BOTH proposals before either executes.
+		require.NoError(t, gov.ExpectedOk(gov.GovImp.Transact(owner, "addProposalToAddMember", w1gInfo(C.From, C.From, C.From, dupNode, "C dup"))))
+		ballotC := getBallotIdx(t, gov)
+		require.NoError(t, gov.ExpectedOk(gov.GovImp.Transact(owner, "addProposalToAddMember", w1gInfo(D.From, D.From, D.From, dupNode, "D dup"))))
+		ballotD := getBallotIdx(t, gov)
+
+		voteAccept(t, gov, ballotC, owner) // owner sole -> C added, markers set
+		cIdx := getMemberIdx(t, gov, C.From)
+		require.Equal(t, int64(2), w1gMemberLength(t, gov))
+
+		voteAccept(t, gov, ballotD, owner, C) // legacy addMember does NOT re-check
+		dIdx := getMemberIdx(t, gov, D.From)
+
+		// RED: D was added with the SAME node identity -> duplicate validators.
+		require.True(t, w1gBool(t, gov, "isStaker", D.From), "RED: D should be wrongly admitted on legacy")
+		require.Equal(t, int64(3), w1gMemberLength(t, gov))
+		require.Equal(t, getNodeEnode(t, gov, cIdx), getNodeEnode(t, gov, dIdx), "RED: two members share one enode")
+	})
+
+	t.Run("GREEN_after_upgrade", func(t *testing.T) {
+		gov := NewGovernance(t).DeployContractsLegacy(t)
+		owner := gov.owner
+		C := getTxOpt(t, "w01_C")
+		D := getTxOpt(t, "w01_D")
+		w1gFundAndStake(t, gov, C)
+		w1gFundAndStake(t, gov, D)
+
+		require.NoError(t, gov.ExpectedOk(gov.GovImp.Transact(owner, "addProposalToAddMember", w1gInfo(C.From, C.From, C.From, dupNode, "C dup"))))
+		ballotC := getBallotIdx(t, gov)
+		require.NoError(t, gov.ExpectedOk(gov.GovImp.Transact(owner, "addProposalToAddMember", w1gInfo(D.From, D.From, D.From, dupNode, "D dup"))))
+		ballotD := getBallotIdx(t, gov)
+
+		voteAccept(t, gov, ballotC, owner) // C added on legacy
+		cIdx := getMemberIdx(t, gov, C.From)
+		require.Equal(t, int64(2), w1gMemberLength(t, gov))
+
+		// upgrade with the D proposal STILL QUEUED, then execute it on the fixed impl.
+		upgradeGovToFixed(t, gov, owner, owner, C)
+		voteAccept(t, gov, ballotD, owner, C)
+
+		// GREEN: fixed addMember re-validates uniqueness -> D rejected.
+		require.False(t, w1gBool(t, gov, "isStaker", D.From), "GREEN: D must be rejected at execution")
+		require.Equal(t, int64(2), w1gMemberLength(t, gov))
+		require.Equal(t, dupNode.enode, getNodeEnode(t, gov, cIdx))
+	})
+}
+
+// ==========================================================================
+// W1G-02 — stale removal must not empty governance
+// ==========================================================================
+
+// W1G-02: a removal proposal created while >1 members exist must not be able
+// to drop the member count to zero when executed later as a stale ballot.
+func TestW1G02_StaleRemovalCannotEmptyGovernance(t *testing.T) {
+	gov := NewGovernance(t).DeployContracts(t)
+	owner := gov.owner
+	B := getTxOpt(t, "w1g02_B")
+	nodeB := nodeInfo{[]byte("w1g02-B"), w1gEnode("ffffffff"), []byte("127.0.0.21"), big.NewInt(8542)}
+
+	// register B -> members {owner(A), B}, memberLength=2
+	w1gFundAndStake(t, gov, B)
+	infoB := w1gInfo(B.From, B.From, B.From, nodeB, "add B")
+	require.NoError(t, gov.ExpectedOk(gov.GovImp.Transact(owner, "addProposalToAddMember", infoB)))
+	require.NoError(t, gov.ExpectedOk(gov.GovImp.Transact(owner, "vote", getBallotIdx(t, gov), true)))
+	require.Equal(t, int64(2), w1gMemberLength(t, gov))
+
+	// STALE proposal to remove A, created while memberLength==2 (passes creation > 1)
+	require.NoError(t, gov.ExpectedOk(gov.GovImp.Transact(owner, "addProposalToRemoveMember", owner.From, LOCK_AMOUNT, []byte("rm A stale"), big.NewInt(86400), LOCK_AMOUNT, big.NewInt(0))))
+	staleBallotA := getBallotIdx(t, gov)
+
+	// remove B (owner + B vote) -> memberLength 2 -> 1 (A sole remaining)
+	require.NoError(t, gov.ExpectedOk(gov.GovImp.Transact(owner, "addProposalToRemoveMember", B.From, LOCK_AMOUNT, []byte("rm B"), big.NewInt(86400), LOCK_AMOUNT, big.NewInt(0))))
+	rmB := getBallotIdx(t, gov)
+	require.NoError(t, gov.ExpectedOk(gov.GovImp.Transact(owner, "vote", rmB, true)))
+	require.NoError(t, gov.ExpectedOk(gov.GovImp.Transact(B, "vote", rmB, true)))
+	require.Equal(t, int64(1), w1gMemberLength(t, gov))
+	require.True(t, w1gBool(t, gov, "isStaker", owner.From))
+
+	// execute the stale removal against the SOLE member A (A votes, weight 10000)
+	require.NoError(t, gov.ExpectedOk(gov.GovImp.Transact(owner, "vote", staleBallotA, true)))
+
+	// W1G-02: removeMember re-checks getMemberLength() > 1 -> A NOT removed
+	require.Equal(t, int64(1), w1gMemberLength(t, gov))
+	require.True(t, w1gBool(t, gov, "isStaker", owner.From))
+}
+
+// ============================================================================
+// W1G-02 — stale removal empties governance.  RED on legacy, GREEN after upgrade.
+//
+// A removal proposal created while >1 members exist is executed later, after
+// the member count has dropped to 1. On LEGACY removeMember has no >1 re-check,
+// so the last member is removed and memberLength hits 0 (network bricked). The
+// fixed contract re-checks and rejects (NotApplicable).
+// ============================================================================
+func TestW1G02_Legacy_EmptyGovernance_RedThenGreen(t *testing.T) {
+	nodeB := nodeInfo{[]byte("w02-B"), w1gEnode("02020202"), []byte("10.2.0.2"), big.NewInt(8542)}
+
+	// builds: members {owner, B}, a STALE removal-of-owner ballot, then removes B
+	// so only owner remains. returns the stale ballot id (Ready, not yet executed).
+	build := func(t *testing.T, gov *Governance, B *bind.TransactOpts) *big.Int {
+		owner := gov.owner
+		addPlainMember(t, gov, owner, B, nodeB, "add B", owner)
+		require.Equal(t, int64(2), w1gMemberLength(t, gov))
+
+		// stale removal of owner, created while memberLength==2 (passes creation >1).
+		require.NoError(t, gov.ExpectedOk(gov.GovImp.Transact(
+			owner, "addProposalToRemoveMember", owner.From, LOCK_AMOUNT, []byte("rm owner stale"), big.NewInt(86400), LOCK_AMOUNT, big.NewInt(0))))
+		stale := getBallotIdx(t, gov)
+
+		// remove B -> only owner remains (memberLength 2 -> 1).
+		require.NoError(t, gov.ExpectedOk(gov.GovImp.Transact(
+			owner, "addProposalToRemoveMember", B.From, LOCK_AMOUNT, []byte("rm B"), big.NewInt(86400), LOCK_AMOUNT, big.NewInt(0))))
+		voteAccept(t, gov, getBallotIdx(t, gov), owner, B)
+		require.Equal(t, int64(1), w1gMemberLength(t, gov))
+		return stale
+	}
+
+	t.Run("RED_legacy", func(t *testing.T) {
+		gov := NewGovernance(t).DeployContractsLegacy(t)
+		owner := gov.owner
+		B := getTxOpt(t, "w02_B")
+		stale := build(t, gov, B)
+
+		// execute the stale removal against the SOLE member (owner self-votes, weight 10000).
+		voteAccept(t, gov, stale, owner)
+
+		// RED: legacy removeMember has no >1 guard -> governance emptied.
+		require.Equal(t, int64(0), w1gMemberLength(t, gov), "RED: memberLength should reach 0 on legacy")
+		require.False(t, w1gBool(t, gov, "isStaker", owner.From))
+	})
+
+	t.Run("GREEN_after_upgrade", func(t *testing.T) {
+		gov := NewGovernance(t).DeployContractsLegacy(t)
+		owner := gov.owner
+		B := getTxOpt(t, "w02_B")
+		stale := build(t, gov, B)
+
+		upgradeGovToFixed(t, gov, owner, owner) // owner is sole member, weight 10000
+
+		// execute the stale removal on the fixed impl.
+		voteAccept(t, gov, stale, owner)
+
+		// GREEN: fixed removeMember re-checks >1 -> sole member preserved.
+		require.Equal(t, int64(1), w1gMemberLength(t, gov), "GREEN: sole member must survive")
+		require.True(t, w1gBool(t, gov, "isStaker", owner.From))
+	})
+}
+
+// ==========================================================================
+// W1G-03 — migration / reInit marker integrity
+// ==========================================================================
+
+// W1G-03 (migrateFromLegacy): migrating from a legacy gov must copy the member
+// ledger 1..N consistently and re-establish node-uniqueness markers. This also
+// exercises the fixed duplicate check (checkNodeInfoChange(.., node) -> the real
+// checkNodeInfoAdd): unique legacy nodes must pass migration without reverting.
+//
+// Teeth limitation: the duplicate-rejection branch only fires for a legacy gov
+// that already holds duplicate node metadata, which the uniqueness-enforcing
+// contracts cannot produce; that case needs a mock legacy and is out of scope here.
+func TestW1G03_MigrateFromLegacyIntegrity(t *testing.T) {
+	gov := NewGovernance(t).DeployContracts(t) // legacy gov, owner = member 1
+	owner := gov.owner
+	B := getTxOpt(t, "w1g03_mig_B")
+	nodeB := nodeInfo{[]byte("w1g03m-B"), w1gEnode("12121212"), []byte("127.0.0.31"), big.NewInt(8542)}
+
+	// legacy gains a 2nd member
+	w1gFundAndStake(t, gov, B)
+	infoB := w1gInfo(B.From, B.From, B.From, nodeB, "add B")
+	require.NoError(t, gov.ExpectedOk(gov.GovImp.Transact(owner, "addProposalToAddMember", infoB)))
+	require.NoError(t, gov.ExpectedOk(gov.GovImp.Transact(owner, "vote", getBallotIdx(t, gov), true)))
+	require.Equal(t, int64(2), w1gMemberLength(t, gov))
+
+	// legacy gov proxy address (resolved from the shared registry)
+	var legacyAddr common.Address
+	require.NoError(t, gov.Registry.Call(new(bind.CallOpts), &[]interface{}{&legacyAddr}, "getContractAddress", ToBytes32("GovernanceContract")))
+
+	// deploy a fresh implementation + proxy, then migrate the legacy state into it
+	newImpAddr, _, err := gov.Deploy(compiled.GovImp.Deploy(gov.backend, owner))
+	require.NoError(t, err)
+	newProxyAddr, _, err := gov.Deploy(compiled.Gov.Deploy(gov.backend, owner, newImpAddr))
+	require.NoError(t, err)
+	newGov := compiled.GovImp.New(gov.backend, newProxyAddr)
+
+	require.NoError(t, gov.ExpectedOk(newGov.Transact(owner, "migrateFromLegacy", legacyAddr)))
+
+	// the migrated ledger must be 1..N consistent (no off-by-one / index corruption)
+	var ml *big.Int
+	require.NoError(t, newGov.Call(new(bind.CallOpts), &[]interface{}{&ml}, "getMemberLength"))
+	require.Equal(t, int64(2), ml.Int64())
+	w1gCheckMemberOn(t, newGov, big.NewInt(1), w1gInfo(owner.From, owner.From, owner.From, gov.nodeInfos[0], ""))
+	w1gCheckMemberOn(t, newGov, big.NewInt(2), infoB)
+}
+
+// W1G-03 (reInit): reInit backfills node-uniqueness markers across 1..N.
+// After reInit, every member node (including the LAST one) must remain
+// uniqueness-protected.
+//
+// Teeth limitation: the 1..N (vs buggy 0..N-1) loop only changes observable
+// behaviour when markers start empty (a pre-marker in-place upgrade). In a fresh
+// deploy addMember already sets markers, so this test confirms reInit runs and
+// does not corrupt uniqueness; the off-by-one's teeth need a pre-marker fixture.
+func TestW1G03_ReInitPreservesNodeUniqueness(t *testing.T) {
+	gov := NewGovernance(t).DeployContracts(t)
+	owner := gov.owner
+	B := getTxOpt(t, "w1g03_ri_B")
+	nodeB := nodeInfo{[]byte("w1g03r-B"), w1gEnode("34343434"), []byte("127.0.0.41"), big.NewInt(8542)}
+
+	w1gFundAndStake(t, gov, B)
+	infoB := w1gInfo(B.From, B.From, B.From, nodeB, "add B")
+	require.NoError(t, gov.ExpectedOk(gov.GovImp.Transact(owner, "addProposalToAddMember", infoB)))
+	require.NoError(t, gov.ExpectedOk(gov.GovImp.Transact(owner, "vote", getBallotIdx(t, gov), true)))
+	require.Equal(t, int64(2), w1gMemberLength(t, gov)) // owner is the last node here
+
+	// reInit (reinitializer(2), owner-only) must not revert
+	require.NoError(t, gov.ExpectedOk(gov.GovImp.Transact(owner, "reInit")))
+
+	// node uniqueness still enforced after reInit: reusing the LAST member's enode is rejected
+	C := getTxOpt(t, "w1g03_ri_C")
+	w1gFundAndStake(t, gov, C)
+	dupOfB := w1gInfo(C.From, C.From, C.From, nodeInfo{[]byte("w1g03r-C"), nodeB.enode, []byte("127.0.0.42"), big.NewInt(8542)}, "dup enode of B")
+	ExpectedRevert(t,
+		gov.ExpectedFail(gov.GovImp.Transact(owner, "addProposalToAddMember", dupOfB)),
+		"Duplicated node info",
+	)
+}
+
+// ============================================================================
+// W1G-03 (migrate) — dead duplicate-check.  RED on legacy, GREEN on fixed.
+//
+// A legacy gov is driven (via the legacy W1G-01 bug) into holding two members
+// with the SAME node metadata. Migrating that ledger with the LEGACY
+// migrateFromLegacy (checkNodeInfoChange(.., node) -> always true) silently
+// accepts the duplicate; the FIXED migrateFromLegacy (checkNodeInfoAdd) rejects
+// it with "node info is duplicated".
+// ============================================================================
+func TestW1G03_Legacy_MigrateDeadCheck_RedThenGreen(t *testing.T) {
+	dupNode := nodeInfo{[]byte("w03m-dup"), w1gEnode("03030303"), []byte("10.3.0.9"), big.NewInt(8542)}
+
+	// build a legacy source gov that already holds a duplicate node, return its proxy addr.
+	buildDuplicateLegacy := func(t *testing.T, gov *Governance) common.Address {
+		owner := gov.owner
+		C := getTxOpt(t, "w03m_C")
+		D := getTxOpt(t, "w03m_D")
+		w1gFundAndStake(t, gov, C)
+		w1gFundAndStake(t, gov, D)
+		require.NoError(t, gov.ExpectedOk(gov.GovImp.Transact(owner, "addProposalToAddMember", w1gInfo(C.From, C.From, C.From, dupNode, "C"))))
+		ballotC := getBallotIdx(t, gov)
+		require.NoError(t, gov.ExpectedOk(gov.GovImp.Transact(owner, "addProposalToAddMember", w1gInfo(D.From, D.From, D.From, dupNode, "D"))))
+		ballotD := getBallotIdx(t, gov)
+		voteAccept(t, gov, ballotC, owner)
+		voteAccept(t, gov, ballotD, owner, C)
+		require.Equal(t, int64(3), w1gMemberLength(t, gov)) // owner, C, D (C & D duplicate node)
+
+		var srcAddr common.Address
+		require.NoError(t, gov.Registry.Call(new(bind.CallOpts), &[]interface{}{&srcAddr}, "getContractAddress", ToBytes32("GovernanceContract")))
+		return srcAddr
+	}
+
+	t.Run("RED_legacy_migrate_accepts_duplicate", func(t *testing.T) {
+		gov := NewGovernance(t).DeployContractsLegacy(t)
+		owner := gov.owner
+		srcAddr := buildDuplicateLegacy(t, gov)
+
+		// fresh LEGACY impl + proxy, migrate the duplicate-bearing ledger into it.
+		impl, _, err := gov.Deploy(compiled.GovImpLegacy.Deploy(gov.backend, owner))
+		require.NoError(t, err)
+		proxy, _, err := gov.Deploy(compiled.Gov.Deploy(gov.backend, owner, impl))
+		require.NoError(t, err)
+		newLegacy := compiled.GovImpLegacy.New(gov.backend, proxy)
+
+		// RED: dead check -> migration succeeds despite the duplicate.
+		require.NoError(t, gov.ExpectedOk(newLegacy.Transact(owner, "migrateFromLegacy", srcAddr)))
+		var ml *big.Int
+		require.NoError(t, newLegacy.Call(new(bind.CallOpts), &[]interface{}{&ml}, "getMemberLength"))
+		require.Equal(t, int64(3), ml.Int64(), "RED: duplicate ledger migrated wholesale on legacy")
+	})
+
+	t.Run("GREEN_fixed_migrate_rejects_duplicate", func(t *testing.T) {
+		gov := NewGovernance(t).DeployContractsLegacy(t)
+		owner := gov.owner
+		srcAddr := buildDuplicateLegacy(t, gov)
+
+		// fresh FIXED impl + proxy, migrate the same ledger -> must revert.
+		impl, _, err := gov.Deploy(compiled.GovImp.Deploy(gov.backend, owner))
+		require.NoError(t, err)
+		proxy, _, err := gov.Deploy(compiled.Gov.Deploy(gov.backend, owner, impl))
+		require.NoError(t, err)
+		newFixed := compiled.GovImp.New(gov.backend, proxy)
+
+		// GREEN: fixed migrate re-checks uniqueness -> reverts at the duplicate.
+		// (Asserted via Contains because the shared ExpectedRevert helper mangles
+		// revert strings whose leading chars collide with "execution reverted:".)
+		migErr := gov.ExpectedFail(newFixed.Transact(owner, "migrateFromLegacy", srcAddr))
+		require.Error(t, migErr)
+		require.Contains(t, migErr.Error(), "node info is duplicated")
+	})
+}
+
+// ============================================================================
+// W1G-03 (migrate) — ledger preservation for a SEPARATED member.
+//
+// migrateFromLegacy copies getMember(i)/getVoter(i)/getReward(i) independently,
+// so a member whose staker / voter / reward keys were self-separated on the
+// legacy gov must survive migration with all three index maps still pointing at
+// the same slot. This exercises the migrate path (distinct from the changeGov
+// upgrade path) on a separated ledger — the "ledger preservation" concern of
+// 검증 2 — using the fixed migrateFromLegacy on a clean (non-duplicate) source.
+// ============================================================================
+func TestW1G03_Legacy_MigratePreservesSeparation(t *testing.T) {
+	gov := NewGovernance(t).DeployContractsLegacy(t)
+	owner := gov.owner
+	B := getTxOpt(t, "w03s_B")
+	Bv := getTxOpt(t, "w03s_Bv")
+	Br := getTxOpt(t, "w03s_Br")
+	C := getTxOpt(t, "w03s_C")
+	nodeB := nodeInfo{[]byte("w03s-B"), w1gEnode("06060606"), []byte("10.3.2.2"), big.NewInt(8542)}
+	nodeC := nodeInfo{[]byte("w03s-C"), w1gEnode("07070707"), []byte("10.3.2.3"), big.NewInt(8542)}
+
+	// legacy ledger: owner(1), B(2) self-separated to Bv/Br, C(3) plain.
+	bIdx := addPlainMember(t, gov, owner, B, nodeB, "add B", owner)
+	infoBsep := w1gInfo(B.From, Bv.From, Br.From, nodeB, "separate B")
+	require.NoError(t, gov.ExpectedOk(gov.GovImp.Transact(B, "addProposalToChangeMember", infoBsep, B.From, big.NewInt(0), big.NewInt(0))))
+	checkGovMember(t, gov, bIdx, infoBsep)
+	cIdx := addPlainMember(t, gov, owner, C, nodeC, "add C", owner, B)
+	require.Equal(t, int64(3), w1gMemberLength(t, gov))
+
+	// legacy source proxy address.
+	var srcAddr common.Address
+	require.NoError(t, gov.Registry.Call(new(bind.CallOpts), &[]interface{}{&srcAddr}, "getContractAddress", ToBytes32("GovernanceContract")))
+
+	// fresh FIXED impl + proxy, migrate the separated ledger into it.
+	impl, _, err := gov.Deploy(compiled.GovImp.Deploy(gov.backend, owner))
+	require.NoError(t, err)
+	proxy, _, err := gov.Deploy(compiled.Gov.Deploy(gov.backend, owner, impl))
+	require.NoError(t, err)
+	newGov := compiled.GovImp.New(gov.backend, proxy)
+	require.NoError(t, gov.ExpectedOk(newGov.Transact(owner, "migrateFromLegacy", srcAddr)))
+
+	// migrated ledger: every slot 1..N consistent, and the SEPARATED member B
+	// keeps stakerIdx[B]==voterIdx[Bv]==rewardIdx[Br]==nodeIdx[B]==bIdx.
+	var ml *big.Int
+	require.NoError(t, newGov.Call(new(bind.CallOpts), &[]interface{}{&ml}, "getMemberLength"))
+	require.Equal(t, int64(3), ml.Int64())
+	w1gCheckMemberOn(t, newGov, big.NewInt(1), w1gInfo(owner.From, owner.From, owner.From, gov.nodeInfos[0], ""))
+	w1gCheckMemberOn(t, newGov, bIdx, infoBsep) // separation preserved through migration
+	w1gCheckMemberOn(t, newGov, cIdx, w1gInfo(C.From, C.From, C.From, nodeC, ""))
+
+	// sanity: the separated voter resolves to its staker on the migrated gov.
+	var stakerOfBv common.Address
+	require.NoError(t, newGov.Call(new(bind.CallOpts), &[]interface{}{&stakerOfBv}, "getStakerAddr", Bv.From))
+	require.Equal(t, B.From, stakerOfBv)
+}
+
+// ============================================================================
+// W1G-03 (reInit) — marker-backfill off-by-one.  RED on pre-marker, GREEN fixed.
+//
+// On an implementation that never maintained node-uniqueness markers (the state
+// reInit's backfill exists to repair), the LEGACY reInit loops 0..N-1: it marks
+// the empty nodes[0] sentinel and SKIPS the last real node nodes[N]. That last
+// member's identifier is therefore left reusable. The fixed reInit (1..N) marks
+// every real node, so the last member's identifier is protected.
+// ============================================================================
+func TestW1G03_PreMarker_ReInitOffByOne_RedThenGreen(t *testing.T) {
+	nodeB := nodeInfo{[]byte("w03r-B"), w1gEnode("04040404"), []byte("10.3.1.2"), big.NewInt(8542)}
+	nodeC := nodeInfo{[]byte("w03r-C"), w1gEnode("05050505"), []byte("10.3.1.3"), big.NewInt(8542)} // the LAST member's node
+
+	build := func(t *testing.T, gov *Governance) (B, C *bind.TransactOpts) {
+		owner := gov.owner
+		B = getTxOpt(t, "w03r_B")
+		C = getTxOpt(t, "w03r_C")
+		addPlainMember(t, gov, owner, B, nodeB, "add B", owner)
+		addPlainMember(t, gov, owner, C, nodeC, "add C", owner, B) // C is the LAST member (index 3)
+		require.Equal(t, int64(3), w1gMemberLength(t, gov))
+		return
+	}
+
+	t.Run("RED_premarker_buggy_reInit_skips_last_node", func(t *testing.T) {
+		gov := NewGovernance(t).DeployContractsPreMarker(t)
+		owner := gov.owner
+		B, C := build(t, gov)
+		cIdx := getMemberIdx(t, gov, C.From) // the LAST member (index 3)
+
+		// buggy reInit (0..N-1): marks nodes[0..2] (sentinel + owner + B), skips nodes[3]=C.
+		require.NoError(t, gov.ExpectedOk(gov.GovImp.Transact(owner, "reInit")))
+
+		// reusing B's enode (marked) is correctly blocked...
+		E := getTxOpt(t, "w03r_E")
+		w1gFundAndStake(t, gov, E)
+		reuseB := w1gInfo(E.From, E.From, E.From, nodeInfo{[]byte("w03r-E1"), nodeB.enode, []byte("10.3.1.7"), big.NewInt(8542)}, "reuse B enode")
+		ExpectedRevert(t, gov.ExpectedFail(gov.GovImp.Transact(owner, "addProposalToAddMember", reuseB)), "Duplicated node info")
+
+		// ...but reusing the LAST member C's enode SLIPS THROUGH (off-by-one left it
+		// unmarked), and PreMarker's addMember has no execution-time re-check either,
+		// so the duplicate is fully ADMITTED (proposal -> vote -> executed add).
+		reuseC := w1gInfo(E.From, E.From, E.From, nodeInfo{[]byte("w03r-E2"), nodeC.enode, []byte("10.3.1.8"), big.NewInt(8542)}, "reuse C enode")
+		require.NoError(t, gov.ExpectedOk(gov.GovImp.Transact(owner, "addProposalToAddMember", reuseC)),
+			"RED: last node's enode should be wrongly reusable after buggy reInit")
+		voteAccept(t, gov, getBallotIdx(t, gov), owner, B) // owner + B reach quorum (E is the target)
+
+		eIdx := getMemberIdx(t, gov, E.From)
+		require.True(t, w1gBool(t, gov, "isStaker", E.From), "RED: duplicate-enode member wrongly admitted")
+		require.Equal(t, int64(4), w1gMemberLength(t, gov))
+		require.Equal(t, getNodeEnode(t, gov, cIdx), getNodeEnode(t, gov, eIdx), "RED: E and the LAST member C share one enode")
+	})
+
+	t.Run("GREEN_fixed_reInit_marks_last_node", func(t *testing.T) {
+		gov := NewGovernance(t).DeployContractsPreMarker(t)
+		owner := gov.owner
+		B, C := build(t, gov)
+		_ = C
+
+		// upgrade runs the FIXED reInit (1..N) -> every real node marked, incl. the last.
+		upgradeGovToFixed(t, gov, owner, owner, B)
+
+		// reusing the LAST member C's enode is now correctly blocked.
+		E := getTxOpt(t, "w03r_E")
+		w1gFundAndStake(t, gov, E)
+		reuseC := w1gInfo(E.From, E.From, E.From, nodeInfo{[]byte("w03r-E2"), nodeC.enode, []byte("10.3.1.8"), big.NewInt(8542)}, "reuse C enode")
+		ExpectedRevert(t,
+			gov.ExpectedFail(gov.GovImp.Transact(owner, "addProposalToAddMember", reuseC)),
+			"Duplicated node info",
+		)
+	})
+}
+
+// ==========================================================================
+// W1G-04 — staker/voter identification & separation
+// ==========================================================================
+
+// W1G-04: after a staker self-separates its voter/reward, verify the ledger,
+// that a voter-only address cannot drive a self-finalized change (no slot-0
+// corruption), and that both the separated voter and the staker can still
+// operate normally afterwards.
+func TestW1G04_StakerVoterSeparationLifecycle(t *testing.T) {
+	callOpts := new(bind.CallOpts)
+	gov := NewGovernance(t).DeployContracts(t)
+	owner := gov.owner
+
+	B := getTxOpt(t, "w1g04_B")
+	Bv := getTxOpt(t, "w1g04_B_voter")
+	Br := getTxOpt(t, "w1g04_B_reward")
+	C := getTxOpt(t, "w1g04_C")
+
+	nodeB := nodeInfo{[]byte("w1g04-B"), w1gEnode("bbbbbbbb"), []byte("127.0.0.11"), big.NewInt(8542)}
+	nodeX := nodeInfo{[]byte("w1g04-X"), w1gEnode("cccccccc"), []byte("127.0.0.99"), big.NewInt(9999)}
+	nodeY := nodeInfo{[]byte("w1g04-Y"), w1gEnode("dddddddd"), []byte("127.0.0.12"), big.NewInt(8543)}
+	nodeC := nodeInfo{[]byte("w1g04-C"), w1gEnode("eeeeeeee"), []byte("127.0.0.13"), big.NewInt(8544)}
+
+	// register member B (staker=voter=reward=B): memberLength 1 -> 2
+	w1gFundAndStake(t, gov, B)
+	infoB := w1gInfo(B.From, B.From, B.From, nodeB, "add B")
+	require.NoError(t, gov.ExpectedOk(gov.GovImp.Transact(owner, "addProposalToAddMember", infoB)))
+	require.NoError(t, gov.ExpectedOk(gov.GovImp.Transact(owner, "vote", getBallotIdx(t, gov), true)))
+	bIdx := getMemberIdx(t, gov, B.From)
+	checkGovMember(t, gov, bIdx, infoB)
+
+	// S1: staker B self-updates to SEPARATE voter & reward (self-finalized, no vote)
+	infoBsep := w1gInfo(B.From, Bv.From, Br.From, nodeB, "separate B")
+	require.NoError(t, gov.ExpectedOk(gov.GovImp.Transact(B, "addProposalToChangeMember", infoBsep, B.From, big.NewInt(0), big.NewInt(0))))
+	checkGovMember(t, gov, bIdx, infoBsep) // stakerIdx[B]=voterIdx[Bv]=rewardIdx[Br]=nodeIdx[B]=bIdx
+	require.True(t, w1gBool(t, gov, "isStaker", B.From))
+	require.False(t, w1gBool(t, gov, "isVoter", B.From))
+	require.True(t, w1gBool(t, gov, "isVoter", Bv.From))
+	require.False(t, w1gBool(t, gov, "isStaker", Bv.From))
+	require.Equal(t, B.From, w1gStakerAddr(t, gov, Bv.From))
+
+	// the separated voter key needs gas to send its own transactions (it stakes nothing)
+	require.NoError(t, gov.ExpectedOk(TransferCoin(gov.backend, gov.owner, towei(2_000_000), &Bv.From)))
+
+	// S2: voter-only address (Bv, stakerIdx==0) attempts a self-finalized change.
+	// MUST be rejected ("Non-member") with no state mutation / slot-0 poisoning.
+	infoExploit := w1gInfo(Bv.From, Bv.From, Bv.From, nodeX, "exploit")
+	ExpectedRevert(t,
+		gov.ExpectedFail(gov.GovImp.Transact(Bv, "addProposalToChangeMember", infoExploit, Bv.From, big.NewInt(0), big.NewInt(0))),
+		"Non-member",
+	)
+	checkGovMember(t, gov, bIdx, infoBsep) // B entry unchanged
+	require.True(t, w1gBool(t, gov, "isVoter", Bv.From))
+	require.False(t, w1gBool(t, gov, "isStaker", Bv.From))
+	{ // slot 0 stays empty (no node/role written into the sentinel index)
+		var m0, v0 common.Address
+		require.NoError(t, gov.GovImp.Call(callOpts, &[]interface{}{&m0}, "getMember", big.NewInt(0)))
+		require.NoError(t, gov.GovImp.Call(callOpts, &[]interface{}{&v0}, "getVoter", big.NewInt(0)))
+		require.Equal(t, common.Address{}, m0)
+		require.Equal(t, common.Address{}, v0)
+	}
+
+	// S4: the real staker B can still self-update its own node (self-finalized)
+	infoBnode := w1gInfo(B.From, Bv.From, Br.From, nodeY, "update B node")
+	require.NoError(t, gov.ExpectedOk(gov.GovImp.Transact(B, "addProposalToChangeMember", infoBnode, B.From, big.NewInt(0), big.NewInt(0))))
+	checkGovMember(t, gov, bIdx, infoBnode)
+
+	// S3: the separated VOTER (Bv) can both PROPOSE and VOTE (operational path).
+	// Bv proposes adding C; owner + Bv (B's voter) vote -> 2/2 stakers accept -> C added.
+	w1gFundAndStake(t, gov, C)
+	infoC := w1gInfo(C.From, C.From, C.From, nodeC, "add C")
+	require.NoError(t, gov.ExpectedOk(gov.GovImp.Transact(Bv, "addProposalToAddMember", infoC)))
+	cBallot := getBallotIdx(t, gov)
+	require.NoError(t, gov.ExpectedOk(gov.GovImp.Transact(owner, "vote", cBallot, true)))
+	require.NoError(t, gov.ExpectedOk(gov.GovImp.Transact(Bv, "vote", cBallot, true)))
+	cIdx := getMemberIdx(t, gov, C.From)
+	checkGovMember(t, gov, cIdx, infoC)
+	require.Equal(t, int64(3), w1gMemberLength(t, gov))
+}
+
+// D1: a VOTED full member change (proposed by another member, finalized by vote)
+// of a previously-separated member must clear the SEPARATED voter/reward keys
+// (read from the member index, not from oldStaker) and leave the ledger consistent.
+func TestW1G04_VotedChangeOfSeparatedMember(t *testing.T) {
+	gov := NewGovernance(t).DeployContracts(t)
+	owner := gov.owner
+	B := getTxOpt(t, "d1_B")
+	Bv := getTxOpt(t, "d1_Bv")
+	Br := getTxOpt(t, "d1_Br")
+	T := getTxOpt(t, "d1_T")
+	nodeB := nodeInfo{[]byte("d1-B"), w1gEnode("a1a1a1a1"), []byte("127.0.1.1"), big.NewInt(8542)}
+	nodeT := nodeInfo{[]byte("d1-T"), w1gEnode("a2a2a2a2"), []byte("127.0.1.2"), big.NewInt(8542)}
+
+	// add B, then B self-separates voter & reward
+	w1gFundAndStake(t, gov, B)
+	infoB := w1gInfo(B.From, B.From, B.From, nodeB, "add B")
+	require.NoError(t, gov.ExpectedOk(gov.GovImp.Transact(owner, "addProposalToAddMember", infoB)))
+	require.NoError(t, gov.ExpectedOk(gov.GovImp.Transact(owner, "vote", getBallotIdx(t, gov), true)))
+	bIdx := getMemberIdx(t, gov, B.From)
+	require.NoError(t, gov.ExpectedOk(TransferCoin(gov.backend, owner, towei(2_000_000), &Bv.From))) // voter gas
+	infoBsep := w1gInfo(B.From, Bv.From, Br.From, nodeB, "separate B")
+	require.NoError(t, gov.ExpectedOk(gov.GovImp.Transact(B, "addProposalToChangeMember", infoBsep, B.From, big.NewInt(0), big.NewInt(0))))
+	checkGovMember(t, gov, bIdx, infoBsep)
+
+	// VOTED full change B -> T (msg.sender=owner != B, so it goes through voting)
+	w1gFundAndStake(t, gov, T)
+	infoT := w1gInfo(T.From, T.From, T.From, nodeT, "change B to T")
+	// unlockAmount = LOCK_AMOUNT (== minStaking) so the exit takes the plain-unlock
+	// branch in transferLockedAndUnlock (matches the existing change-totally test).
+	require.NoError(t, gov.ExpectedOk(gov.GovImp.Transact(owner, "addProposalToChangeMember", infoT, B.From, LOCK_AMOUNT, big.NewInt(0))))
+	chBallot := getBallotIdx(t, gov)
+	require.NoError(t, gov.ExpectedOk(gov.GovImp.Transact(owner, "vote", chBallot, true)))
+	require.NoError(t, gov.ExpectedOk(gov.GovImp.Transact(Bv, "vote", chBallot, true))) // B votes via its separated voter
+
+	// slot now holds T; every old (separated) key is cleared, no stale mappings
+	checkGovMember(t, gov, bIdx, infoT)
+	require.False(t, w1gBool(t, gov, "isStaker", B.From))
+	require.False(t, w1gBool(t, gov, "isVoter", Bv.From))
+	require.False(t, w1gBool(t, gov, "isReward", Br.From))
+	require.Equal(t, int64(2), w1gMemberLength(t, gov))
+}
+
+// D2: the VOTED change path must also reject a voter-only target at creation
+// ("Non-member"), complementing the self-finalized case (S2 in the lifecycle test).
+func TestW1G04_VotedPathRejectsVoterOnlyTarget(t *testing.T) {
+	gov := NewGovernance(t).DeployContracts(t)
+	owner := gov.owner
+	B := getTxOpt(t, "d2_B")
+	Bv := getTxOpt(t, "d2_Bv")
+	nodeB := nodeInfo{[]byte("d2-B"), w1gEnode("b1b1b1b1"), []byte("127.0.2.1"), big.NewInt(8542)}
+	nodeX := nodeInfo{[]byte("d2-X"), w1gEnode("b2b2b2b2"), []byte("127.0.2.2"), big.NewInt(8542)}
+
+	w1gFundAndStake(t, gov, B)
+	infoB := w1gInfo(B.From, B.From, B.From, nodeB, "add B")
+	require.NoError(t, gov.ExpectedOk(gov.GovImp.Transact(owner, "addProposalToAddMember", infoB)))
+	require.NoError(t, gov.ExpectedOk(gov.GovImp.Transact(owner, "vote", getBallotIdx(t, gov), true)))
+
+	// B separates its voter -> Bv (voter-only, stakerIdx==0)
+	infoBsep := w1gInfo(B.From, Bv.From, B.From, nodeB, "separate voter")
+	require.NoError(t, gov.ExpectedOk(gov.GovImp.Transact(B, "addProposalToChangeMember", infoBsep, B.From, big.NewInt(0), big.NewInt(0))))
+	bIdx := getMemberIdx(t, gov, B.From)
+
+	// owner proposes a voted change targeting the voter-only address Bv -> rejected at creation
+	infoX := w1gInfo(Bv.From, Bv.From, Bv.From, nodeX, "voted exploit")
+	ExpectedRevert(t,
+		gov.ExpectedFail(gov.GovImp.Transact(owner, "addProposalToChangeMember", infoX, Bv.From, big.NewInt(0), big.NewInt(0))),
+		"Non-member",
+	)
+	checkGovMember(t, gov, bIdx, infoBsep) // unchanged
+}
+
+// D3: reward-only separation. The staker keeps staker==voter but moves the reward
+// to a distinct address; the reward index must move while staker/voter stay, and a
+// later self-update must keep the separated reward consistent.
+func TestW1G04_RewardSeparationLedger(t *testing.T) {
+	gov := NewGovernance(t).DeployContracts(t)
+	owner := gov.owner
+	B := getTxOpt(t, "d3_B")
+	Br := getTxOpt(t, "d3_Br")
+	nodeB := nodeInfo{[]byte("d3-B"), w1gEnode("c1c1c1c1"), []byte("127.0.3.1"), big.NewInt(8542)}
+	nodeY := nodeInfo{[]byte("d3-Y"), w1gEnode("c2c2c2c2"), []byte("127.0.3.2"), big.NewInt(8542)}
+
+	w1gFundAndStake(t, gov, B)
+	infoB := w1gInfo(B.From, B.From, B.From, nodeB, "add B")
+	require.NoError(t, gov.ExpectedOk(gov.GovImp.Transact(owner, "addProposalToAddMember", infoB)))
+	require.NoError(t, gov.ExpectedOk(gov.GovImp.Transact(owner, "vote", getBallotIdx(t, gov), true)))
+	bIdx := getMemberIdx(t, gov, B.From)
+
+	// separate ONLY the reward (staker==voter==B, reward=Br)
+	infoBsep := w1gInfo(B.From, B.From, Br.From, nodeB, "separate reward")
+	require.NoError(t, gov.ExpectedOk(gov.GovImp.Transact(B, "addProposalToChangeMember", infoBsep, B.From, big.NewInt(0), big.NewInt(0))))
+	checkGovMember(t, gov, bIdx, infoBsep)
+	require.True(t, w1gBool(t, gov, "isStaker", B.From))
+	require.True(t, w1gBool(t, gov, "isVoter", B.From))
+	require.True(t, w1gBool(t, gov, "isReward", Br.From))
+	require.False(t, w1gBool(t, gov, "isReward", B.From))
+
+	// a subsequent self-update (node change) keeps the separated reward consistent
+	infoBnode := w1gInfo(B.From, B.From, Br.From, nodeY, "update node keep sep reward")
+	require.NoError(t, gov.ExpectedOk(gov.GovImp.Transact(B, "addProposalToChangeMember", infoBnode, B.From, big.NewInt(0), big.NewInt(0))))
+	checkGovMember(t, gov, bIdx, infoBnode)
+	require.True(t, w1gBool(t, gov, "isReward", Br.From))
+	require.False(t, w1gBool(t, gov, "isReward", B.From))
+}
+
+// ============================================================================
+// W1G-04 — voter-only address self-change.  RED on legacy, GREEN after upgrade.
+//
+// A staker B self-separates its voter key Bv (legitimate). Bv then has
+// voterIdx[Bv]!=0 but stakerIdx[Bv]==0. On the LEGACY contract Bv can drive a
+// self-finalized "change" of itself: changeMember indexes by stakerIdx[Bv]==0
+// and writes the sentinel slot 0 — poisoning voters[0], destroying Bv's own
+// voter mapping, and squatting attacker-chosen node markers (a DoS on future
+// legitimate registration). The fixed contract rejects it at proposal time.
+// ============================================================================
+func TestW1G04_Legacy_Slot0Poison_RedThenGreen(t *testing.T) {
+	nodeB := nodeInfo{[]byte("w04-B"), w1gEnode("0b0b0b0b"), []byte("10.4.0.2"), big.NewInt(8542)}
+	// attacker-chosen identifier the exploit squats; a legitimate node later wants it.
+	nodeX := nodeInfo{[]byte("w04-X"), w1gEnode("0a0a0a0a"), []byte("10.4.0.9"), big.NewInt(9999)}
+
+	setupSeparated := func(t *testing.T, gov *Governance) (B, Bv, Br *bind.TransactOpts, bIdx *big.Int) {
+		owner := gov.owner
+		B = getTxOpt(t, "w04_B")
+		Bv = getTxOpt(t, "w04_Bv")
+		Br = getTxOpt(t, "w04_Br")
+		bIdx = addPlainMember(t, gov, owner, B, nodeB, "add B", owner)
+		infoBsep := w1gInfo(B.From, Bv.From, Br.From, nodeB, "separate B")
+		require.NoError(t, gov.ExpectedOk(gov.GovImp.Transact(B, "addProposalToChangeMember", infoBsep, B.From, big.NewInt(0), big.NewInt(0))))
+		require.True(t, w1gBool(t, gov, "isVoter", Bv.From))
+		require.False(t, w1gBool(t, gov, "isStaker", Bv.From))
+		require.NoError(t, gov.ExpectedOk(TransferCoin(gov.backend, owner, towei(2_000_000), &Bv.From)))
+		return
+	}
+
+	t.Run("RED_legacy", func(t *testing.T) {
+		gov := NewGovernance(t).DeployContractsLegacy(t)
+		owner := gov.owner
+		B, Bv, _, _ := setupSeparated(t, gov)
+
+		// EXPLOIT: voter-only Bv drives a self-finalized change of itself.
+		infoExploit := w1gInfo(Bv.From, Bv.From, Bv.From, nodeX, "exploit via voter-only key")
+		require.NoError(t, gov.ExpectedOk(gov.GovImp.Transact(Bv, "addProposalToChangeMember", infoExploit, Bv.From, big.NewInt(0), big.NewInt(0))))
+
+		// (1) Bv's own voter mapping was destroyed (voterIdx[Bv] overwritten to 0).
+		require.False(t, w1gBool(t, gov, "isVoter", Bv.From), "RED: Bv voter mapping should be corrupted on legacy")
+		// (2) sentinel slot 0 poisoned with Bv as a voter.
+		require.Equal(t, Bv.From, getVoterAt(t, gov, big.NewInt(0)), "RED: voters[0] poisoned on legacy")
+		// (3) attacker squatted nodeX's markers -> a legitimate member can no longer use nodeX (DoS).
+		C := getTxOpt(t, "w04_C")
+		w1gFundAndStake(t, gov, C)
+		infoLegit := w1gInfo(C.From, C.From, C.From, nodeX, "legit C wants nodeX")
+		ExpectedRevert(t,
+			gov.ExpectedFail(gov.GovImp.Transact(owner, "addProposalToAddMember", infoLegit)),
+			"Duplicated node info",
+		)
+		// B's real entry is otherwise intact (bIdx still maps to B as staker).
+		require.True(t, w1gBool(t, gov, "isStaker", B.From))
+	})
+
+	t.Run("GREEN_after_upgrade", func(t *testing.T) {
+		gov := NewGovernance(t).DeployContractsLegacy(t)
+		owner := gov.owner
+		B, Bv, _, bIdx := setupSeparated(t, gov)
+
+		upgradeGovToFixed(t, gov, owner, owner, B) // 2 members: owner + B
+
+		// exploit now rejected at proposal time ("Non-member": Bv is not a staker).
+		infoExploit := w1gInfo(Bv.From, Bv.From, Bv.From, nodeX, "exploit via voter-only key")
+		ExpectedRevert(t,
+			gov.ExpectedFail(gov.GovImp.Transact(Bv, "addProposalToChangeMember", infoExploit, Bv.From, big.NewInt(0), big.NewInt(0))),
+			"Non-member",
+		)
+		require.True(t, w1gBool(t, gov, "isVoter", Bv.From), "GREEN: Bv voter mapping intact")
+		require.Equal(t, common.Address{}, getVoterAt(t, gov, big.NewInt(0)), "GREEN: slot 0 clean")
+		_ = bIdx
+
+		// and nodeX is still available to a legitimate member (no squatting happened).
+		C := getTxOpt(t, "w04_C")
+		w1gFundAndStake(t, gov, C)
+		infoLegit := w1gInfo(C.From, C.From, C.From, nodeX, "legit C uses nodeX")
+		require.NoError(t, gov.ExpectedOk(gov.GovImp.Transact(owner, "addProposalToAddMember", infoLegit)))
+		voteAccept(t, gov, getBallotIdx(t, gov), owner, B)
+		require.True(t, w1gBool(t, gov, "isStaker", C.From))
+	})
+}
+
+// ==========================================================================
+// End-to-end — legacy ledger -> proxy upgrade -> exercise every core flow
+// ==========================================================================
+
+// ============================================================================
+// 검증 2 / 3 / 5 — Legacy ledger -> upgrade -> exercise EVERY core flow.
+//
+// Builds a 3-member legacy ledger where member B has a self-separated
+// staker/voter/reward, upgrades the proxy to the fixed GovImp, then drives
+// propose / vote / execute for add, change (self & voted), env, and remove —
+// initiated and voted via BOTH staker and the separated voter address — and
+// asserts the W1G-04 staker/voter identification rule (passing a voter-only
+// address as oldStaker reverts "Non-member", passing the staker works).
+// ============================================================================
+func TestW1G_LegacyUpgrade_FullLifecycle(t *testing.T) {
+	gov := NewGovernance(t).DeployContractsLegacy(t)
+	owner := gov.owner // member 1 (staker==voter==reward)
+
+	B := getTxOpt(t, "lc_B")
+	Bv := getTxOpt(t, "lc_Bv")
+	Br := getTxOpt(t, "lc_Br")
+	C := getTxOpt(t, "lc_C")
+	D := getTxOpt(t, "lc_D")
+	T := getTxOpt(t, "lc_T")
+
+	nodeB := nodeInfo{[]byte("lc-B"), w1gEnode("b0b0b0b0"), []byte("10.1.0.2"), big.NewInt(8542)}
+	nodeBy := nodeInfo{[]byte("lc-B2"), w1gEnode("b1b1b1b1"), []byte("10.1.0.3"), big.NewInt(8542)}
+	nodeC := nodeInfo{[]byte("lc-C"), w1gEnode("c0c0c0c0"), []byte("10.1.0.4"), big.NewInt(8542)}
+	nodeD := nodeInfo{[]byte("lc-D"), w1gEnode("d0d0d0d0"), []byte("10.1.0.5"), big.NewInt(8542)}
+	nodeT := nodeInfo{[]byte("lc-T"), w1gEnode("70707070"), []byte("10.1.0.6"), big.NewInt(8542)}
+
+	// --- build the LEGACY ledger (pre-fix contract) ------------------------
+	require.Equal(t, int64(1), w1gMemberLength(t, gov))
+
+	// member B (plain), then C (plain): owner is sole member -> owner's vote finalizes.
+	bIdx := addPlainMember(t, gov, owner, B, nodeB, "add B (legacy)", owner)
+	require.Equal(t, int64(2), w1gMemberLength(t, gov))
+	cIdx := addPlainMember(t, gov, owner, C, nodeC, "add C (legacy)", owner, B)
+	require.Equal(t, int64(3), w1gMemberLength(t, gov))
+
+	// B self-separates voter+reward on the LEGACY contract (self-finalized).
+	infoBsep := w1gInfo(B.From, Bv.From, Br.From, nodeB, "separate B (legacy)")
+	require.NoError(t, gov.ExpectedOk(gov.GovImp.Transact(B, "addProposalToChangeMember", infoBsep, B.From, big.NewInt(0), big.NewInt(0))))
+	checkGovMember(t, gov, bIdx, infoBsep)
+	require.True(t, w1gBool(t, gov, "isVoter", Bv.From))
+	require.False(t, w1gBool(t, gov, "isStaker", Bv.From))
+	require.Equal(t, B.From, w1gStakerAddr(t, gov, Bv.From))
+	require.NoError(t, gov.ExpectedOk(TransferCoin(gov.backend, owner, towei(2_000_000), &Bv.From))) // gas for the voter key
+
+	// --- UPGRADE proxy to the fixed GovImp (real governance path) + reInit --
+	// quorum among {owner, B, C}: owner proposes, owner + B(via staker) vote.
+	upgradeGovToFixed(t, gov, owner, owner, B, C)
+
+	// ledger survived the upgrade unchanged (state preserved through proxy).
+	checkGovMember(t, gov, bIdx, infoBsep)
+	checkGovMember(t, gov, cIdx, w1gInfo(C.From, C.From, C.From, nodeC, ""))
+	require.Equal(t, int64(3), w1gMemberLength(t, gov))
+
+	// ====================================================================
+	// FLOW 1 — propose ADD via the separated VOTER (Bv), execute via vote.
+	//          vote with a mix of staker (owner, C) and voter (Bv) keys.
+	// ====================================================================
+	w1gFundAndStake(t, gov, D)
+	infoD := w1gInfo(D.From, D.From, D.From, nodeD, "add D via voter Bv")
+	require.NoError(t, gov.ExpectedOk(gov.GovImp.Transact(Bv, "addProposalToAddMember", infoD))) // voter proposes
+	dBallot := getBallotIdx(t, gov)
+	voteAccept(t, gov, dBallot, owner, Bv, C) // owner(staker)+Bv(voter for B)+C(staker)
+	dIdx := getMemberIdx(t, gov, D.From)
+	checkGovMember(t, gov, dIdx, infoD)
+	require.Equal(t, int64(4), w1gMemberLength(t, gov))
+
+	// ====================================================================
+	// FLOW 2 — 검증 5: oldStaker identification on the FIXED contract.
+	//   (a) passing the separated VOTER address Bv as oldStaker -> "Non-member"
+	//   (b) passing the real STAKER address B as oldStaker -> OK (self-update)
+	// ====================================================================
+	infoViaVoter := w1gInfo(B.From, Bv.From, Br.From, nodeBy, "change via voter key (must fail)")
+	ExpectedRevert(t,
+		gov.ExpectedFail(gov.GovImp.Transact(B, "addProposalToChangeMember", infoViaVoter, Bv.From, big.NewInt(0), big.NewInt(0))),
+		"Non-member",
+	)
+	checkGovMember(t, gov, bIdx, infoBsep) // unchanged by the rejected attempt
+
+	// (b) same change but oldStaker = the real staker B -> self-finalized OK.
+	infoBupd := w1gInfo(B.From, Bv.From, Br.From, nodeBy, "B self-updates node")
+	require.NoError(t, gov.ExpectedOk(gov.GovImp.Transact(B, "addProposalToChangeMember", infoBupd, B.From, big.NewInt(0), big.NewInt(0))))
+	checkGovMember(t, gov, bIdx, infoBupd)
+
+	// ====================================================================
+	// FLOW 3 — VOTED full member change C -> T (proposed by the voter Bv),
+	//          voted by staker(owner) + voter(Bv). Exercises the voted path.
+	// ====================================================================
+	w1gFundAndStake(t, gov, T)
+	infoT := w1gInfo(T.From, T.From, T.From, nodeT, "change C to T")
+	// unlockAmount == minStaking so transferLockedAndUnlock takes the plain-unlock branch.
+	require.NoError(t, gov.ExpectedOk(gov.GovImp.Transact(Bv, "addProposalToChangeMember", infoT, C.From, LOCK_AMOUNT, big.NewInt(0))))
+	chBallot := getBallotIdx(t, gov)
+	voteAccept(t, gov, chBallot, owner, Bv, D) // staker + voter + staker
+	checkGovMember(t, gov, cIdx, infoT)        // slot now holds T
+	require.False(t, w1gBool(t, gov, "isStaker", C.From))
+	require.True(t, w1gBool(t, gov, "isStaker", T.From))
+	require.Equal(t, int64(4), w1gMemberLength(t, gov))
+
+	// ====================================================================
+	// FLOW 4 — propose+vote+execute an ENV change (proposed by staker owner).
+	//          Sets blocksPer to 100 and verifies the value actually applied.
+	// ====================================================================
+	var blocksPer *big.Int
+	require.NoError(t, gov.EnvStorageImp.Call(new(bind.CallOpts), &[]interface{}{&blocksPer}, "getBlocksPer"))
+	require.NotEqual(t, big.NewInt(100), blocksPer)
+	require.NoError(t, gov.ExpectedOk(gov.GovImp.Transact(owner, "addProposalToChangeEnv",
+		crypto.Keccak256Hash([]byte("blocksPer")),
+		EnvTypes.Uint,
+		hexutil.MustDecode("0x0000000000000000000000000000000000000000000000000000000000000064"), // 100
+		[]byte("env memo"), big.NewInt(86400))))
+	envBallot := getBallotIdx(t, gov)
+	voteAccept(t, gov, envBallot, owner, Bv, D)
+	require.NoError(t, gov.EnvStorageImp.Call(new(bind.CallOpts), &[]interface{}{&blocksPer}, "getBlocksPer"))
+	require.Equal(t, big.NewInt(100), blocksPer) // env change applied through the fixed contract
+
+	// ====================================================================
+	// FLOW 5 — propose+vote+execute REMOVE of member D (proposed by voter Bv).
+	// ====================================================================
+	require.NoError(t, gov.ExpectedOk(gov.GovImp.Transact(
+		Bv, "addProposalToRemoveMember", D.From, LOCK_AMOUNT, []byte("remove D"), big.NewInt(86400), LOCK_AMOUNT, big.NewInt(0))))
+	rmBallot := getBallotIdx(t, gov)
+	voteAccept(t, gov, rmBallot, owner, Bv, T) // owner + B(via Bv) + T
+	require.False(t, w1gBool(t, gov, "isStaker", D.From))
+	require.Equal(t, int64(3), w1gMemberLength(t, gov))
+
+	// final ledger consistency for the surviving members.
+	checkGovMember(t, gov, bIdx, infoBupd)
+}
+
+// ============================================================================
+// 검증 2 보강 — voter-driven ENV and GOV proposals.
+//
+// Complements the FullLifecycle test (where the separated voter drives add /
+// change / remove). Here the separated voter key Bv ALSO proposes — and helps
+// vote in — an env change and a governance (implementation) change, the two
+// proposal kinds that carry no member-identification argument. Confirms a
+// voter-only key drives every proposal kind end to end after the upgrade.
+// ============================================================================
+func TestW1G_VoterDrivenEnvAndGovProposals(t *testing.T) {
+	gov := NewGovernance(t).DeployContractsLegacy(t)
+	owner := gov.owner
+	B := getTxOpt(t, "vd_B")
+	Bv := getTxOpt(t, "vd_Bv")
+	Br := getTxOpt(t, "vd_Br")
+	nodeB := nodeInfo{[]byte("vd-B"), w1gEnode("08080808"), []byte("10.5.0.2"), big.NewInt(8542)}
+
+	// legacy ledger: owner(1), B(2) self-separated to Bv/Br.
+	bIdx := addPlainMember(t, gov, owner, B, nodeB, "add B", owner)
+	infoBsep := w1gInfo(B.From, Bv.From, Br.From, nodeB, "separate B")
+	require.NoError(t, gov.ExpectedOk(gov.GovImp.Transact(B, "addProposalToChangeMember", infoBsep, B.From, big.NewInt(0), big.NewInt(0))))
+	checkGovMember(t, gov, bIdx, infoBsep)
+	require.NoError(t, gov.ExpectedOk(TransferCoin(gov.backend, owner, towei(2_000_000), &Bv.From))) // gas for the voter key
+
+	// upgrade to the fixed impl (owner + B vote) + reInit. members: {owner, B}.
+	upgradeGovToFixed(t, gov, owner, owner, B)
+
+	// ---- ENV change PROPOSED BY THE VOTER Bv, voted by owner + Bv ----------
+	var blocksPer *big.Int
+	require.NoError(t, gov.EnvStorageImp.Call(new(bind.CallOpts), &[]interface{}{&blocksPer}, "getBlocksPer"))
+	require.NotEqual(t, big.NewInt(100), blocksPer)
+	require.NoError(t, gov.ExpectedOk(gov.GovImp.Transact(Bv, "addProposalToChangeEnv",
+		crypto.Keccak256Hash([]byte("blocksPer")),
+		EnvTypes.Uint,
+		hexutil.MustDecode("0x0000000000000000000000000000000000000000000000000000000000000064"), // 100
+		[]byte("env via voter"), big.NewInt(86400))))
+	voteAccept(t, gov, getBallotIdx(t, gov), owner, Bv)
+	require.NoError(t, gov.EnvStorageImp.Call(new(bind.CallOpts), &[]interface{}{&blocksPer}, "getBlocksPer"))
+	require.Equal(t, big.NewInt(100), blocksPer) // env change applied via a voter-proposed ballot
+
+	// ---- GOV (implementation) change PROPOSED BY THE VOTER Bv -------------
+	nextImp, _, err := gov.Deploy(compiled.GovImp.Deploy(gov.backend, owner))
+	require.NoError(t, err)
+	require.NotEqual(t, govImplementation(t, gov), nextImp)
+	require.NoError(t, gov.ExpectedOk(gov.GovImp.Transact(Bv, "addProposalToChangeGov", nextImp, []byte("gov via voter"), big.NewInt(86400))))
+	voteAccept(t, gov, getBallotIdx(t, gov), owner, Bv)
+	require.Equal(t, nextImp, govImplementation(t, gov), "voter-proposed governance change must apply")
+
+	// ledger still intact after both voter-driven proposals.
+	checkGovMember(t, gov, bIdx, infoBsep)
+	require.Equal(t, int64(2), w1gMemberLength(t, gov))
 }

--- a/wemix/governance-contract/test/gov_test.go
+++ b/wemix/governance-contract/test/gov_test.go
@@ -3743,43 +3743,6 @@ func TestW1G03_MigrateFromLegacyIntegrity(t *testing.T) {
 	w1gCheckMemberOn(t, newGov, big.NewInt(2), infoB)
 }
 
-// W1G-03 (reInit): reInit backfills node-uniqueness markers across 1..N.
-// After reInit, every member node (including the LAST one) must remain
-// uniqueness-protected.
-//
-// Teeth limitation: the 1..N (vs buggy 0..N-1) loop only changes observable
-// behaviour when markers start empty (a pre-marker in-place upgrade). In a fresh
-// deploy addMember already sets markers, so even a buggy 0-indexed reInit that
-// skips the last node leaves that node's marker set — this test alone cannot
-// distinguish the buggy reInit from the fixed one. It is therefore a smoke test
-// (reInit runs and does not corrupt uniqueness on a fresh deploy); the
-// off-by-one's actual teeth live in TestW1G03_PreMarker_ReInitOffByOne_RedThenGreen,
-// which uses the GovImpPreMarker fixture (empty markers) to make the skip observable.
-func TestW1G03_ReInitPreservesNodeUniqueness(t *testing.T) {
-	gov := NewGovernance(t).DeployContracts(t)
-	owner := gov.owner
-	B := getTxOpt(t, "w1g03_ri_B")
-	nodeB := nodeInfo{[]byte("w1g03r-B"), w1gEnode("34343434"), []byte("127.0.0.41"), big.NewInt(8542)}
-
-	w1gFundAndStake(t, gov, B)
-	infoB := w1gInfo(B.From, B.From, B.From, nodeB, "add B")
-	require.NoError(t, gov.ExpectedOk(gov.GovImp.Transact(owner, "addProposalToAddMember", infoB)))
-	require.NoError(t, gov.ExpectedOk(gov.GovImp.Transact(owner, "vote", getBallotIdx(t, gov), true)))
-	require.Equal(t, int64(2), w1gMemberLength(t, gov)) // B is the last node here (index 2)
-
-	// reInit (reinitializer(2), owner-only) must not revert
-	require.NoError(t, gov.ExpectedOk(gov.GovImp.Transact(owner, "reInit")))
-
-	// node uniqueness still enforced after reInit: reusing the LAST member's enode is rejected
-	C := getTxOpt(t, "w1g03_ri_C")
-	w1gFundAndStake(t, gov, C)
-	dupOfB := w1gInfo(C.From, C.From, C.From, nodeInfo{[]byte("w1g03r-C"), nodeB.enode, []byte("127.0.0.42"), big.NewInt(8542)}, "dup enode of B")
-	ExpectedRevert(t,
-		gov.ExpectedFail(gov.GovImp.Transact(owner, "addProposalToAddMember", dupOfB)),
-		"Duplicated node info",
-	)
-}
-
 // ============================================================================
 // W1G-03 (migrate) — dead duplicate-check.  RED on legacy, GREEN on fixed.
 //


### PR DESCRIPTION
## Summary
Addresses the four findings (W1G-01..04, all **Minor**) from the CertiK preliminary review of `GovImp`, and adds regression tests. The fixes are logic-only and preserve every external revert/event string, so the on-chain storage layout and the DApp interface are unchanged.

## Findings & fixes (`contracts/GovImp.sol`)
| ID | Issue | Fix |
|----|-------|-----|
| W1G-01 | `addMember` does not re-check node uniqueness at execution, so two queued add proposals carrying the same node metadata can both apply | Re-run `checkNodeInfoAdd` immediately before writing the node; reject with `NotApplicable` on duplicate |
| W1G-02 | `removeMember` lacks the `> 1` member check, so a stale removal executed later can drop the member count to zero | Re-check `getMemberLength() > 1` at execution; reject with `NotApplicable` |
| W1G-03 | `reInit` iterates `0..N-1` (marks the empty slot 0 and skips the last node); `migrateFromLegacy` uses a self-comparing duplicate check that never triggers | `reInit` iterates `1..N` inclusive; migration validates each imported node with `checkNodeInfoAdd` before setting markers |
| W1G-04 | A voter-only address (`stakerIdx == 0`) can drive a self-finalized member update into sentinel slot 0, corrupting staker/voter/reward indexes and squatting node markers | Require `isStaker(oldStaker)` at proposal time; reject `stakerIdx == 0 || nodeIdxFromMember == 0` inside `checkChangeMember` and `removeMember` before any state write |

## Tests (`test/gov_test.go`)
Two test-only mock implementations (`contracts/mock/`) reproduce the behavior of the implementation **before** these fixes. The new tests:
- build a realistic ledger on the previous implementation behind the real proxy (multiple stakers, some with a self-separated voter/reward),
- reproduce each issue on that ledger,
- upgrade the proxy to the new implementation via the normal governance path and run `reInit`,
- confirm each issue is resolved while proposal / vote / execution keep working for add, change, env, governance, and removal — driven by **both** staker and voter keys.

`go test ./...` for the governance-contract package passes (20 top-level tests, no failures).

## Notes for reviewers
- The mock contracts under `contracts/mock/` are compiled only by the test harness and are never referenced by the `gwemix` binary.
- Member/node storage is 1-indexed (slot 0 is an empty sentinel); the W1G-03/04 fixes depend on this.