### PR TITLE
fix: enforce feePayer validation for fee-delegated transactions

### DIFF
--- a/core/error.go
+++ b/core/error.go
@@ -99,7 +99,7 @@ var (
 
 	// fee delegation
 	// ErrInvalidFeePayer is returned if the transaction contains an invalid feePayer's signature.
-	ErrInvalidFeePayer = errors.New("fee delegation: invalid feePayer")
+	ErrInvalidFeePayer = types.ErrInvalidFeePayer
 
 	// ErrFeePayerInsufficientFunds is returned if the fee cost of executing a transaction
 	// is higher than the balance of the feePayer's account.

--- a/core/error.go
+++ b/core/error.go
@@ -98,9 +98,6 @@ var (
 	ErrSenderNoEOA = errors.New("sender not an eoa")
 
 	// fee delegation
-	// ErrInvalidFeePayer is returned if the transaction contains an invalid feePayer's signature.
-	ErrInvalidFeePayer = types.ErrInvalidFeePayer
-
 	// ErrFeePayerInsufficientFunds is returned if the fee cost of executing a transaction
 	// is higher than the balance of the feePayer's account.
 	ErrFeePayerInsufficientFunds = errors.New("fee delegation: insufficient feePayer's funds for gas * price")

--- a/core/tx_pool.go
+++ b/core/tx_pool.go
@@ -706,13 +706,9 @@ func (pool *TxPool) validateTx(tx *types.Transaction, local bool) error {
 
 	// fee delegation
 	if tx.Type() == types.FeeDelegateDynamicFeeTxType {
-		// Make sure the transaction is signed properly.
-		if tx.FeePayer() == nil {
-			return ErrInvalidFeePayer
-		}
-		feePayer, err := types.FeePayer(types.NewFeeDelegateSigner(pool.chainconfig.ChainID), tx)
-		if err != nil || *tx.FeePayer() != feePayer {
-			return ErrInvalidFeePayer
+		feePayer, err := types.RecoverFeePayer(pool.chainconfig.ChainID, tx)
+		if err != nil {
+			return err
 		}
 		if pool.currentState.GetBalance(feePayer).Cmp(tx.FeePayerCost()) < 0 {
 			return ErrFeePayerInsufficientFunds

--- a/core/types/transaction.go
+++ b/core/types/transaction.go
@@ -37,6 +37,7 @@ var (
 	ErrInvalidTxType        = errors.New("transaction type not valid in this context")
 	ErrTxTypeNotSupported   = errors.New("transaction type not supported")
 	ErrGasFeeCapTooLow      = errors.New("fee cap less than base fee")
+	ErrInvalidFeePayer      = errors.New("fee delegation: invalid feePayer")
 	errShortTypedTx         = errors.New("typed transaction too short")
 )
 
@@ -709,9 +710,17 @@ func (tx *Transaction) AsMessage(s Signer, baseFee *big.Int) (Message, error) {
 		accessList: tx.AccessList(),
 		isFake:     false,
 	}
-	// fee delegation
-	if tx.FeePayer() != nil {
-		msg.feePayer = tx.FeePayer()
+	// For fee-delegated tx, verify that FeePayer is set and that
+	// FV/FR/FS recover to the claimed feePayer address.
+	if tx.Type() == FeeDelegateDynamicFeeTxType {
+		if tx.FeePayer() == nil {
+			return msg, ErrInvalidFeePayer
+		}
+		feePayer, err := FeePayer(NewFeeDelegateSigner(s.ChainID()), tx)
+		if err != nil || feePayer != *tx.FeePayer() {
+			return msg, ErrInvalidFeePayer
+		}
+		msg.feePayer = &feePayer
 	}
 	// If baseFee provided, set gasPrice to effectiveGasPrice.
 	if baseFee != nil {

--- a/core/types/transaction.go
+++ b/core/types/transaction.go
@@ -37,8 +37,6 @@ var (
 	ErrInvalidTxType        = errors.New("transaction type not valid in this context")
 	ErrTxTypeNotSupported   = errors.New("transaction type not supported")
 	ErrGasFeeCapTooLow      = errors.New("fee cap less than base fee")
-	ErrFeePayerNotSet       = errors.New("fee delegation: feePayer not set")
-	ErrInvalidFeePayer      = errors.New("fee delegation: invalid feePayer")
 	errShortTypedTx         = errors.New("typed transaction too short")
 )
 
@@ -743,19 +741,6 @@ func (m Message) IsFake() bool           { return m.isFake }
 
 // fee delegation
 func (m Message) FeePayer() *common.Address { return m.feePayer }
-
-// RecoverFeePayer recovers the feePayer address from FV/FR/FS and verifies it
-// matches the claimed FeePayer address. Assumes tx is a fee-delegated transaction.
-func RecoverFeePayer(chainID *big.Int, tx *Transaction) (common.Address, error) {
-	if tx.FeePayer() == nil {
-		return common.Address{}, ErrFeePayerNotSet
-	}
-	feePayer, err := FeePayer(NewFeeDelegateSigner(chainID), tx)
-	if err != nil || feePayer != *tx.FeePayer() {
-		return common.Address{}, ErrInvalidFeePayer
-	}
-	return feePayer, nil
-}
 
 // copyAddressPtr copies an address.
 func copyAddressPtr(a *common.Address) *common.Address {

--- a/core/types/transaction.go
+++ b/core/types/transaction.go
@@ -713,12 +713,9 @@ func (tx *Transaction) AsMessage(s Signer, baseFee *big.Int) (Message, error) {
 	// For fee-delegated tx, verify that FeePayer is set and that
 	// FV/FR/FS recover to the claimed feePayer address.
 	if tx.Type() == FeeDelegateDynamicFeeTxType {
-		if tx.FeePayer() == nil {
-			return msg, ErrInvalidFeePayer
-		}
-		feePayer, err := FeePayer(NewFeeDelegateSigner(s.ChainID()), tx)
-		if err != nil || feePayer != *tx.FeePayer() {
-			return msg, ErrInvalidFeePayer
+		feePayer, err := RecoverFeePayer(s.ChainID(), tx)
+		if err != nil {
+			return msg, err
 		}
 		msg.feePayer = &feePayer
 	}
@@ -745,6 +742,19 @@ func (m Message) IsFake() bool           { return m.isFake }
 
 // fee delegation
 func (m Message) FeePayer() *common.Address { return m.feePayer }
+
+// RecoverFeePayer recovers the feePayer address from FV/FR/FS and verifies it
+// matches the claimed FeePayer address. Assumes tx is a fee-delegated transaction.
+func RecoverFeePayer(chainID *big.Int, tx *Transaction) (common.Address, error) {
+	if tx.FeePayer() == nil {
+		return common.Address{}, ErrInvalidFeePayer
+	}
+	feePayer, err := FeePayer(NewFeeDelegateSigner(chainID), tx)
+	if err != nil || feePayer != *tx.FeePayer() {
+		return common.Address{}, ErrInvalidFeePayer
+	}
+	return feePayer, nil
+}
 
 // copyAddressPtr copies an address.
 func copyAddressPtr(a *common.Address) *common.Address {

--- a/core/types/transaction.go
+++ b/core/types/transaction.go
@@ -37,6 +37,7 @@ var (
 	ErrInvalidTxType        = errors.New("transaction type not valid in this context")
 	ErrTxTypeNotSupported   = errors.New("transaction type not supported")
 	ErrGasFeeCapTooLow      = errors.New("fee cap less than base fee")
+	ErrFeePayerNotSet       = errors.New("fee delegation: feePayer not set")
 	ErrInvalidFeePayer      = errors.New("fee delegation: invalid feePayer")
 	errShortTypedTx         = errors.New("typed transaction too short")
 )
@@ -747,7 +748,7 @@ func (m Message) FeePayer() *common.Address { return m.feePayer }
 // matches the claimed FeePayer address. Assumes tx is a fee-delegated transaction.
 func RecoverFeePayer(chainID *big.Int, tx *Transaction) (common.Address, error) {
 	if tx.FeePayer() == nil {
-		return common.Address{}, ErrInvalidFeePayer
+		return common.Address{}, ErrFeePayerNotSet
 	}
 	feePayer, err := FeePayer(NewFeeDelegateSigner(chainID), tx)
 	if err != nil || feePayer != *tx.FeePayer() {

--- a/core/types/transaction_signing.go
+++ b/core/types/transaction_signing.go
@@ -27,7 +27,13 @@ import (
 	"github.com/ethereum/go-ethereum/params"
 )
 
-var ErrInvalidChainId = errors.New("invalid chain id for signer")
+var (
+	ErrInvalidChainId = errors.New("invalid chain id for signer")
+
+	// fee delegation
+	ErrFeePayerNotSet  = errors.New("fee delegation: feePayer not set")
+	ErrInvalidFeePayer = errors.New("fee delegation: invalid feePayer")
+)
 
 // sigCache is used to cache the derived sender and contains
 // the signer used to derive it.
@@ -191,6 +197,19 @@ func FeePayer(signer Signer, tx *Transaction) (common.Address, error) {
 	}
 	tx.feePayer.Store(sigCache{signer: signer, from: addr})
 	return addr, nil
+}
+
+// RecoverFeePayer recovers the feePayer address from FV/FR/FS and verifies it
+// matches the claimed FeePayer address. Assumes tx is a fee-delegated transaction.
+func RecoverFeePayer(chainID *big.Int, tx *Transaction) (common.Address, error) {
+	if tx.FeePayer() == nil {
+		return common.Address{}, ErrFeePayerNotSet
+	}
+	feePayer, err := FeePayer(NewFeeDelegateSigner(chainID), tx)
+	if err != nil || feePayer != *tx.FeePayer() {
+		return common.Address{}, ErrInvalidFeePayer
+	}
+	return feePayer, nil
 }
 
 // Signer encapsulates transaction signature handling. The name of this type is slightly

--- a/core/types/transaction_test.go
+++ b/core/types/transaction_test.go
@@ -535,36 +535,82 @@ func assertEqual(orig *Transaction, cpy *Transaction) error {
 
 func TestRecoverFeePayer(t *testing.T) {
 	chainID := big.NewInt(1112)
-
-	senderKey, _ := crypto.GenerateKey()
 	feePayerKey, _ := crypto.GenerateKey()
 	attackerKey, _ := crypto.GenerateKey()
-
 	feePayerAddr := crypto.PubkeyToAddress(feePayerKey.PublicKey)
 
-	signedTx, err := SignTx(NewTx(&DynamicFeeTx{
-		ChainID:   chainID,
-		Nonce:     0,
-		GasTipCap: big.NewInt(1),
-		GasFeeCap: big.NewInt(1),
-		Gas:       21000,
-		To:        &feePayerAddr,
-		Value:     big.NewInt(0),
-	}), NewLondonSigner(chainID), senderKey)
-	if err != nil {
-		t.Fatalf("SignTx (sender): %v", err)
-	}
-	senderTx := signedTx.inner.(*DynamicFeeTx)
+	signedSenderTx := setupSenderTx(t, chainID, feePayerAddr)
+	senderTx := signedSenderTx.inner.(*DynamicFeeTx)
+	tests := getFeePayerTestCases(&feePayerAddr, feePayerKey, attackerKey)
 
-	tests := []struct {
-		name            string
-		feePayerAddr    *common.Address
-		feePayerSignKey *ecdsa.PrivateKey
-		wantErr         error
-	}{
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			fdTx := setupFeeDelegateTx(t, chainID, *senderTx, tt.feePayerAddr, tt.feePayerSignKey)
+			recovered, err := RecoverFeePayer(chainID, fdTx)
+			if !errors.Is(err, tt.wantErr) {
+				t.Errorf("expected error %v, got %v", tt.wantErr, err)
+				return
+			}
+			if tt.wantErr == nil {
+				if recovered != feePayerAddr {
+					t.Errorf("recovered address mismatch: got %s, want %s", recovered.Hex(), feePayerAddr.Hex())
+				}
+			}
+		})
+	}
+}
+
+func TestAsMessageFeeDelegation(t *testing.T) {
+	chainID := big.NewInt(1112)
+	feePayerKey, _ := crypto.GenerateKey()
+	attackerKey, _ := crypto.GenerateKey()
+	feePayerAddr := crypto.PubkeyToAddress(feePayerKey.PublicKey)
+
+	signedSenderTx := setupSenderTx(t, chainID, feePayerAddr)
+	senderTx := signedSenderTx.inner.(*DynamicFeeTx)
+
+	// 1. Verify that a non-fee-delegated transaction passes AsMessage validation without error.
+	t.Run("NonFeeDelegateTx", func(t *testing.T) {
+		msg, err := signedSenderTx.AsMessage(NewFeeDelegateSigner(chainID), nil)
+		if err != nil {
+			t.Errorf("expected no error for non-fee-delegated tx, got %v", err)
+		}
+		if msg.FeePayer() != nil {
+			t.Errorf("expected nil FeePayer for non-fee-delegated tx, got %v", msg.FeePayer())
+		}
+	})
+
+	// 2. Verify fee-delegated transaction cases.
+	tests := getFeePayerTestCases(&feePayerAddr, feePayerKey, attackerKey)
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			fdTx := setupFeeDelegateTx(t, chainID, *senderTx, tt.feePayerAddr, tt.feePayerSignKey)
+			msg, err := fdTx.AsMessage(NewFeeDelegateSigner(chainID), nil)
+			if !errors.Is(err, tt.wantErr) {
+				t.Errorf("AsMessage expected error %v, got %v", tt.wantErr, err)
+			}
+			if tt.wantErr == nil {
+				if msg.FeePayer() == nil || *msg.FeePayer() != feePayerAddr {
+					t.Errorf("msg.FeePayer mismatch: got %v, want %v", msg.FeePayer(), feePayerAddr)
+				}
+			}
+		})
+	}
+}
+
+type feePayerTestCase struct {
+	name            string
+	feePayerAddr    *common.Address
+	feePayerSignKey *ecdsa.PrivateKey
+	wantErr         error
+}
+
+// getFeePayerTestCases returns shared test cases for fee-delegation tests.
+func getFeePayerTestCases(feePayerAddr *common.Address, feePayerKey, attackerKey *ecdsa.PrivateKey) []feePayerTestCase {
+	return []feePayerTestCase{
 		{
 			name:            "ValidSignature",
-			feePayerAddr:    &feePayerAddr,
+			feePayerAddr:    feePayerAddr,
 			feePayerSignKey: feePayerKey,
 		},
 		{
@@ -578,43 +624,53 @@ func TestRecoverFeePayer(t *testing.T) {
 		},
 		{
 			name:            "ValidFeePayerWithoutSignature",
-			feePayerAddr:    &feePayerAddr,
+			feePayerAddr:    feePayerAddr,
 			feePayerSignKey: nil,
 			wantErr:         ErrInvalidFeePayer,
 		},
 		{
 			name:            "AddressMismatch",
-			feePayerAddr:    &feePayerAddr,
+			feePayerAddr:    feePayerAddr,
 			feePayerSignKey: attackerKey,
 			wantErr:         ErrInvalidFeePayer,
 		},
 	}
+}
 
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			fdTx := NewTx(&FeeDelegateDynamicFeeTx{
-				SenderTx: *senderTx,
-				FeePayer: tt.feePayerAddr,
-				FV:       new(big.Int),
-				FR:       new(big.Int),
-				FS:       new(big.Int),
-			})
-			if tt.feePayerSignKey != nil {
-				fdTx, err = SignTx(fdTx, NewFeeDelegateSigner(chainID), tt.feePayerSignKey)
-				if err != nil {
-					t.Fatalf("SignTx (feePayer): %v", err)
-				}
-			}
-			recovered, err := RecoverFeePayer(chainID, fdTx)
-			if !errors.Is(err, tt.wantErr) {
-				t.Errorf("expected error %v, got %v", tt.wantErr, err)
-				return
-			}
-			if tt.wantErr == nil {
-				if recovered != feePayerAddr {
-					t.Errorf("recovered address mismatch: got %s, want %s", recovered.Hex(), feePayerAddr.Hex())
-				}
-			}
-		})
+// setupSenderTx generates a signed DynamicFeeTx for testing fee-delegated transactions.
+func setupSenderTx(t *testing.T, chainID *big.Int, feePayerAddr common.Address) *Transaction {
+	senderKey, _ := crypto.GenerateKey()
+
+	signedTx, err := SignTx(NewTx(&DynamicFeeTx{
+		ChainID:   chainID,
+		Nonce:     0,
+		GasTipCap: big.NewInt(1),
+		GasFeeCap: big.NewInt(1),
+		Gas:       21000,
+		To:        &feePayerAddr,
+		Value:     big.NewInt(0),
+	}), NewLondonSigner(chainID), senderKey)
+	if err != nil {
+		t.Fatalf("setupSenderTx: SignTx (sender): %v", err)
 	}
+	return signedTx
+}
+
+// setupFeeDelegateTx constructs and optionally signs a FeeDelegateDynamicFeeTx for testing.
+func setupFeeDelegateTx(t *testing.T, chainID *big.Int, senderTx DynamicFeeTx, feePayerAddr *common.Address, feePayerSignKey *ecdsa.PrivateKey) *Transaction {
+	fdTx := NewTx(&FeeDelegateDynamicFeeTx{
+		SenderTx: senderTx,
+		FeePayer: feePayerAddr,
+		FV:       new(big.Int),
+		FR:       new(big.Int),
+		FS:       new(big.Int),
+	})
+	if feePayerSignKey != nil {
+		var err error
+		fdTx, err = SignTx(fdTx, NewFeeDelegateSigner(chainID), feePayerSignKey)
+		if err != nil {
+			t.Fatalf("setupFeeDelegateTx: SignTx (feePayer): %v", err)
+		}
+	}
+	return fdTx
 }

--- a/core/types/transaction_test.go
+++ b/core/types/transaction_test.go
@@ -568,10 +568,11 @@ func TestAsMessageFeeDelegation(t *testing.T) {
 
 	signedSenderTx := setupSenderTx(t, chainID, feePayerAddr)
 	senderTx := signedSenderTx.inner.(*DynamicFeeTx)
+	signer := NewLondonSigner(chainID)
 
 	// 1. Verify that a non-fee-delegated transaction passes AsMessage validation without error.
 	t.Run("NonFeeDelegateTx", func(t *testing.T) {
-		msg, err := signedSenderTx.AsMessage(NewFeeDelegateSigner(chainID), nil)
+		msg, err := signedSenderTx.AsMessage(signer, nil)
 		if err != nil {
 			t.Errorf("expected no error for non-fee-delegated tx, got %v", err)
 		}
@@ -585,7 +586,7 @@ func TestAsMessageFeeDelegation(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			fdTx := setupFeeDelegateTx(t, chainID, *senderTx, tt.feePayerAddr, tt.feePayerSignKey)
-			msg, err := fdTx.AsMessage(NewFeeDelegateSigner(chainID), nil)
+			msg, err := fdTx.AsMessage(signer, nil)
 			if !errors.Is(err, tt.wantErr) {
 				t.Errorf("AsMessage expected error %v, got %v", tt.wantErr, err)
 			}

--- a/core/types/transaction_test.go
+++ b/core/types/transaction_test.go
@@ -20,6 +20,7 @@ import (
 	"bytes"
 	"crypto/ecdsa"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"math/big"
 	"math/rand"
@@ -530,4 +531,90 @@ func assertEqual(orig *Transaction, cpy *Transaction) error {
 		}
 	}
 	return nil
+}
+
+func TestRecoverFeePayer(t *testing.T) {
+	chainID := big.NewInt(1112)
+
+	senderKey, _ := crypto.GenerateKey()
+	feePayerKey, _ := crypto.GenerateKey()
+	attackerKey, _ := crypto.GenerateKey()
+
+	feePayerAddr := crypto.PubkeyToAddress(feePayerKey.PublicKey)
+
+	signedTx, err := SignTx(NewTx(&DynamicFeeTx{
+		ChainID:   chainID,
+		Nonce:     0,
+		GasTipCap: big.NewInt(1),
+		GasFeeCap: big.NewInt(1),
+		Gas:       21000,
+		To:        &feePayerAddr,
+		Value:     big.NewInt(0),
+	}), NewLondonSigner(chainID), senderKey)
+	if err != nil {
+		t.Fatalf("SignTx (sender): %v", err)
+	}
+	senderTx := signedTx.inner.(*DynamicFeeTx)
+
+	tests := []struct {
+		name            string
+		feePayerAddr    *common.Address
+		feePayerSignKey *ecdsa.PrivateKey
+		wantErr         error
+	}{
+		{
+			name:            "ValidSignature",
+			feePayerAddr:    &feePayerAddr,
+			feePayerSignKey: feePayerKey,
+		},
+		{
+			name:    "NilFeePayerWithoutSignature",
+			wantErr: ErrFeePayerNotSet,
+		},
+		{
+			name:            "NilFeePayerWithSignature",
+			feePayerSignKey: feePayerKey,
+			wantErr:         ErrFeePayerNotSet,
+		},
+		{
+			name:            "ValidFeePayerWithoutSignature",
+			feePayerAddr:    &feePayerAddr,
+			feePayerSignKey: nil,
+			wantErr:         ErrInvalidFeePayer,
+		},
+		{
+			name:            "AddressMismatch",
+			feePayerAddr:    &feePayerAddr,
+			feePayerSignKey: attackerKey,
+			wantErr:         ErrInvalidFeePayer,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			fdTx := NewTx(&FeeDelegateDynamicFeeTx{
+				SenderTx: *senderTx,
+				FeePayer: tt.feePayerAddr,
+				FV:       new(big.Int),
+				FR:       new(big.Int),
+				FS:       new(big.Int),
+			})
+			if tt.feePayerSignKey != nil {
+				fdTx, err = SignTx(fdTx, NewFeeDelegateSigner(chainID), tt.feePayerSignKey)
+				if err != nil {
+					t.Fatalf("SignTx (feePayer): %v", err)
+				}
+			}
+			recovered, err := RecoverFeePayer(chainID, fdTx)
+			if !errors.Is(err, tt.wantErr) {
+				t.Errorf("expected error %v, got %v", tt.wantErr, err)
+				return
+			}
+			if tt.wantErr == nil {
+				if recovered != feePayerAddr {
+					t.Errorf("recovered address mismatch: got %s, want %s", recovered.Hex(), feePayerAddr.Hex())
+				}
+			}
+		})
+	}
 }

--- a/internal/ethapi/api.go
+++ b/internal/ethapi/api.go
@@ -1919,10 +1919,6 @@ func SubmitTransaction(ctx context.Context, b Backend, tx *types.Transaction) (c
 		// Ensure only eip155 signed transactions are submitted if EIP155Required is set.
 		return common.Hash{}, errors.New("only replay-protected (EIP-155) transactions allowed over RPC")
 	}
-	// fee delegation
-	if tx.Type() == types.FeeDelegateDynamicFeeTxType && tx.FeePayer() == nil {
-		return common.Hash{}, errors.New("FeePayer address is null")
-	}
 	if err := b.SendTx(ctx, tx); err != nil {
 		return common.Hash{}, err
 	}
@@ -1931,16 +1927,6 @@ func SubmitTransaction(ctx context.Context, b Backend, tx *types.Transaction) (c
 	from, err := types.Sender(signer, tx)
 	if err != nil {
 		return common.Hash{}, err
-	}
-	// fee delegation
-	if tx.Type() == types.FeeDelegateDynamicFeeTxType {
-		feePayer, err := types.FeePayer(types.NewFeeDelegateSigner(b.ChainConfig().ChainID), tx)
-		if err != nil {
-			return common.Hash{}, err
-		}
-		if feePayer != *tx.FeePayer() {
-			return common.Hash{}, errors.New("FeePayer Signature error")
-		}
 	}
 
 	if tx.To() == nil {

--- a/light/txpool.go
+++ b/light/txpool.go
@@ -391,9 +391,9 @@ func (pool *TxPool) validateTx(ctx context.Context, tx *types.Transaction) error
 			return core.ErrTxTypeNotSupported
 		}
 		// Make sure the transaction is signed properly.
-		feePayer, err := types.FeePayer(types.NewFeeDelegateSigner(pool.config.ChainID), tx)
-		if *tx.FeePayer() != feePayer || err != nil {
-			return core.ErrInvalidFeePayer
+		feePayer, err := types.RecoverFeePayer(pool.config.ChainID, tx)
+		if err != nil {
+			return err
 		}
 		if currentState.GetBalance(feePayer).Cmp(tx.FeePayerCost()) < 0 {
 			return core.ErrFeePayerInsufficientFunds


### PR DESCRIPTION
## Overview

Resolve the missing fee payer signature validation for fee-delegated transactions (Type 22) during block execution.

## Problem

Fee payer signatures for fee-delegated transactions were validated during txpool entry and RPC receipt, but this validation was missing in the block execution path. An adversarial block proposer could bypass the txpool and directly insert a transaction with an invalid fee payer signature into a block, meaning that the transaction is processed without proper signature validation.

Additionally, a transaction with a `nil` fee payer address would not be rejected, causing gas fees to incorrectly fall back to the transaction sender.

## Solution

Enforce type checks, nil checks, and fee payer signature verification in the block execution path.

## Changes

- Enforce fee payer signature validation during block execution by calling `RecoverFeePayer` in `AsMessage`.
- Define `ErrFeePayerNotSet` to explicitly reject transactions with a `nil` fee payer address in `AsMessage`.
- Introduce `RecoverFeePayer` function in `core/types/transaction_signing.go` to unify validation logic.
- Replace inline fee payer verification blocks with calls to `RecoverFeePayer` in `AsMessage`, `tx_pool.go`, `light/txpool.go`, and `internal/ethapi/api.go`.