### PR TITLE
fix: pre-allocate AccessList slice in SetSenderTx before copying

### DIFF
--- a/core/types/feedelegate_dynamic_fee_tx.go
+++ b/core/types/feedelegate_dynamic_fee_tx.go
@@ -40,6 +40,7 @@ func (tx *FeeDelegateDynamicFeeTx) SetSenderTx(senderTx DynamicFeeTx) {
 	tx.SenderTx.To = senderTx.To
 	tx.SenderTx.Value = senderTx.Value
 	tx.SenderTx.Data = senderTx.Data
+	tx.SenderTx.AccessList = make(AccessList, len(senderTx.AccessList))
 	copy(tx.SenderTx.AccessList, senderTx.AccessList)
 
 	v, r, s := senderTx.rawSignatureValues()

--- a/core/types/transaction_test.go
+++ b/core/types/transaction_test.go
@@ -675,3 +675,62 @@ func setupFeeDelegateTx(t *testing.T, chainID *big.Int, senderTx DynamicFeeTx, f
 	}
 	return fdTx
 }
+
+// TestSetSenderTxAccessListPreserved verifies that SetSenderTx correctly copies a non-empty
+// AccessList so that sender/feePayer signature recovery succeeds on the RPC assembly path.
+func TestSetSenderTxAccessListPreserved(t *testing.T) {
+	chainID := big.NewInt(1112)
+	senderKey, _ := crypto.GenerateKey()
+	feePayerKey, _ := crypto.GenerateKey()
+	feePayerAddr := crypto.PubkeyToAddress(feePayerKey.PublicKey)
+
+	al := AccessList{{
+		Address:     common.HexToAddress("0xdeadbeefdeadbeefdeadbeefdeadbeefdeadbeef"),
+		StorageKeys: []common.Hash{common.HexToHash("0x01")},
+	}}
+
+	signedSenderTx, err := SignTx(NewTx(&DynamicFeeTx{
+		ChainID:    chainID,
+		Nonce:      0,
+		GasTipCap:  big.NewInt(1),
+		GasFeeCap:  big.NewInt(1),
+		Gas:        21000,
+		To:         &feePayerAddr,
+		Value:      big.NewInt(0),
+		AccessList: al,
+	}), NewLondonSigner(chainID), senderKey)
+	if err != nil {
+		t.Fatalf("SignTx (sender): %v", err)
+	}
+
+	senderTx := signedSenderTx.inner.(*DynamicFeeTx)
+	// Replicate the RPC assembly path: construct an empty FeeDelegateDynamicFeeTx and
+	// populate it via SetSenderTx, as done in transaction_args.go and api.go.
+	fd := &FeeDelegateDynamicFeeTx{FeePayer: &feePayerAddr}
+	fd.SetSenderTx(*senderTx)
+
+	if !reflect.DeepEqual(fd.SenderTx.AccessList, al) {
+		t.Fatalf("AccessList not preserved: got %v, want %v", fd.SenderTx.AccessList, al)
+	}
+
+	fdTx, err := SignTx(NewTx(fd), NewFeeDelegateSigner(chainID), feePayerKey)
+	if err != nil {
+		t.Fatalf("SignTx (feePayer): %v", err)
+	}
+
+	recoveredSender, err := NewLondonSigner(chainID).Sender(fdTx)
+	if err != nil {
+		t.Fatalf("sender recovery failed: %v", err)
+	}
+	if recoveredSender != crypto.PubkeyToAddress(senderKey.PublicKey) {
+		t.Errorf("sender mismatch: got %s, want %s", recoveredSender.Hex(), crypto.PubkeyToAddress(senderKey.PublicKey).Hex())
+	}
+
+	recoveredFeePayer, err := RecoverFeePayer(chainID, fdTx)
+	if err != nil {
+		t.Fatalf("feePayer recovery failed: %v", err)
+	}
+	if recoveredFeePayer != feePayerAddr {
+		t.Errorf("feePayer mismatch: got %s, want %s", recoveredFeePayer.Hex(), feePayerAddr.Hex())
+	}
+}


### PR DESCRIPTION
## Overview
Fix a bug where the AccessList in a fee-delegated transaction is lost during RPC assembly, causing signature recovery to fail.

## Problem
When copying the AccessList via `copy`, the destination slice was zero-initialized with no allocated memory, causing all entries to be silently lost and subsequent signature recovery to fail.

## Solution
Pre-allocate memory for the destination AccessList slice before copying to prevent data loss.

## Changes
- `core/types/feedelegate_dynamic_fee_tx.go`: pre-allocate `AccessList` slice with `make` before `copy` in `SetSenderTx`