### PR TITLE
fix: prevent stale work overwrite in syncCheck

### DIFF
--- a/wemix/etcd_test.go
+++ b/wemix/etcd_test.go
@@ -1,0 +1,283 @@
+// Copyright 2025 The go-wemix Authors
+// This file is part of the go-wemix library.
+
+// Tests that require a real embedded etcd cluster. The test spins up a
+// single-node embedded etcd so that etcd transaction semantics are exercised
+// directly, rather than mirrored.
+
+package wemix
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"math/big"
+	"net"
+	"testing"
+	"time"
+
+	"github.com/ethereum/go-ethereum/common"
+	"go.etcd.io/etcd/server/v3/embed"
+	"go.etcd.io/etcd/server/v3/etcdserver/api/v3client"
+)
+
+// freeBasePort returns a base port p such that p+1 (etcd peer) and p+2 (etcd
+// client) are usable. It probes three consecutive ports and only returns once
+// all of them can be bound, to avoid flaky startup collisions.
+func freeBasePort(t *testing.T) int {
+	t.Helper()
+	for attempt := 0; attempt < 20; attempt++ {
+		l, err := net.Listen("tcp", "127.0.0.1:0")
+		if err != nil {
+			continue
+		}
+		base := l.Addr().(*net.TCPAddr).Port
+		l.Close()
+
+		ok := true
+		for _, off := range []int{1, 2} {
+			probe, perr := net.Listen("tcp", fmt.Sprintf("127.0.0.1:%d", base+off))
+			if perr != nil {
+				ok = false
+				break
+			}
+			probe.Close()
+		}
+		if ok {
+			return base
+		}
+	}
+	t.Fatal("could not find three consecutive free ports for embedded etcd")
+	return 0
+}
+
+// newTestEtcdAdmin starts a single-node embedded etcd and returns a
+// *wemixAdmin bound to it.
+//
+// It deliberately does NOT go through (*wemixAdmin).etcdInit: that path spawns
+// the production etcdEventHandler goroutine, which is a process-wide singleton
+// keyed off the package-level `admin` and is not designed to be started and
+// torn down repeatedly inside tests. Since etcdResetWork only depends on a
+// ready etcd client/server (etcdIsReady) and ReqTimeout(), we start the
+// embedded server directly and set etcdReady ourselves.
+func newTestEtcdAdmin(t *testing.T) *wemixAdmin {
+	t.Helper()
+
+	base := freeBasePort(t)
+	ma := &wemixAdmin{
+		self: &wemixNode{
+			Name: "testnode",
+			Ip:   "127.0.0.1",
+			Port: base,
+		},
+		etcdDir:     t.TempDir(),
+		etcdTimeout: 5 * time.Second,
+	}
+
+	cfg := ma.etcdNewConfig(true)
+	etcd, err := embed.StartEtcd(cfg)
+	if err != nil {
+		t.Fatalf("StartEtcd failed: %v", err)
+	}
+
+	select {
+	case <-etcd.Server.ReadyNotify():
+	case <-time.After(30 * time.Second):
+		etcd.Server.Stop()
+		<-etcd.Server.StopNotify()
+		t.Fatal("embedded etcd did not become ready in time")
+	}
+
+	ma.etcd = etcd
+	ma.etcdCli = v3client.New(etcd.Server)
+
+	// etcdIsReady() also checks the package-level etcdReady flag.
+	prevReady := etcdReady
+	etcdReady = true
+
+	t.Cleanup(func() {
+		etcdReady = prevReady
+		if ma.etcdCli != nil {
+			ma.etcdCli.Close()
+		}
+		etcd.Close()
+		// The data dir is a t.TempDir(), cleaned up automatically.
+	})
+
+	return ma
+}
+
+// mustGetWork reads the current wemixWorkKey value, treating a not-found as "".
+func mustGetWork(t *testing.T, ma *wemixAdmin) string {
+	t.Helper()
+	v, err := ma.etcdGet(wemixWorkKey)
+	if err == ErrNotFound {
+		return ""
+	}
+	if err != nil {
+		t.Fatalf("etcdGet(work) failed: %v", err)
+	}
+	return v
+}
+
+func marshalWork(t *testing.T, height int64, hashHex string) string {
+	t.Helper()
+	b, err := json.Marshal(&wemixWork{Height: height, Hash: common.HexToHash(hashHex)})
+	if err != nil {
+		t.Fatalf("marshal work: %v", err)
+	}
+	return string(b)
+}
+
+// TestEtcdResetWork_TokenHeld verifies that a caller holding the exact token
+// stored under wemixTokenKey can overwrite wemixWorkKey.
+func TestEtcdResetWork_TokenHeld(t *testing.T) {
+	ma := newTestEtcdAdmin(t)
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+
+	// Acquire a real token exactly like production (syncCheck) does.
+	token, err := ma.acquireToken(ctx, big.NewInt(1001), MiningTokenTTL)
+	if err != nil {
+		t.Fatalf("acquireToken failed: %v", err)
+	}
+
+	// Seed an initial work value.
+	oldWork := marshalWork(t, 1000, "0x1111111111111111111111111111111111111111111111111111111111111111")
+	if _, err := ma.etcdPut(wemixWorkKey, oldWork); err != nil {
+		t.Fatalf("seed work failed: %v", err)
+	}
+
+	newWork := marshalWork(t, 1001, "0x2222222222222222222222222222222222222222222222222222222222222222")
+	if err := ma.etcdResetWork(token, newWork); err != nil {
+		t.Fatalf("etcdResetWork returned error while holding token: %v", err)
+	}
+
+	if got := mustGetWork(t, ma); got != newWork {
+		t.Fatalf("work not updated: want %q, got %q", newWork, got)
+	}
+}
+
+// TestEtcdResetWork_TokenMismatch verifies that when the stored token differs
+// from the caller's token, the work value is left untouched and ErrInvalidToken
+// is returned.
+func TestEtcdResetWork_TokenMismatch(t *testing.T) {
+	ma := newTestEtcdAdmin(t)
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+
+	// The token actually stored in etcd.
+	stored, err := ma.acquireToken(ctx, big.NewInt(1001), MiningTokenTTL)
+	if err != nil {
+		t.Fatalf("acquireToken failed: %v", err)
+	}
+
+	oldWork := marshalWork(t, 1000, "0x1111111111111111111111111111111111111111111111111111111111111111")
+	if _, err := ma.etcdPut(wemixWorkKey, oldWork); err != nil {
+		t.Fatalf("seed work failed: %v", err)
+	}
+
+	// A different token (different Height) — same shape, not what is stored.
+	other := *stored
+	other.Height = big.NewInt(2002)
+
+	newWork := marshalWork(t, 1001, "0x2222222222222222222222222222222222222222222222222222222222222222")
+	if err := ma.etcdResetWork(&other, newWork); err != ErrInvalidToken {
+		t.Fatalf("expected ErrInvalidToken, got %v", err)
+	}
+
+	if got := mustGetWork(t, ma); got != oldWork {
+		t.Fatalf("work must be unchanged on mismatch: want %q, got %q", oldWork, got)
+	}
+}
+
+// TestEtcdResetWork_TokenAbsent verifies that when no token is present (e.g. it
+// expired and was deleted by another node), the work value is left untouched.
+func TestEtcdResetWork_TokenAbsent(t *testing.T) {
+	ma := newTestEtcdAdmin(t)
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+
+	token, err := ma.acquireToken(ctx, big.NewInt(1001), MiningTokenTTL)
+	if err != nil {
+		t.Fatalf("acquireToken failed: %v", err)
+	}
+
+	oldWork := marshalWork(t, 1000, "0x1111111111111111111111111111111111111111111111111111111111111111")
+	if _, err := ma.etcdPut(wemixWorkKey, oldWork); err != nil {
+		t.Fatalf("seed work failed: %v", err)
+	}
+
+	// Remove the token, simulating expiry/cleanup by another node.
+	if err := ma.etcdDelete(wemixTokenKey); err != nil {
+		t.Fatalf("delete token failed: %v", err)
+	}
+
+	newWork := marshalWork(t, 1001, "0x2222222222222222222222222222222222222222222222222222222222222222")
+	if err := ma.etcdResetWork(token, newWork); err != ErrInvalidToken {
+		t.Fatalf("expected ErrInvalidToken when token absent, got %v", err)
+	}
+
+	if got := mustGetWork(t, ma); got != oldWork {
+		t.Fatalf("work must be unchanged when token absent: want %q, got %q", oldWork, got)
+	}
+}
+
+// TestEtcdResetWork_ExpiredThenSuperseded reproduces the real stale-overwrite
+// scenario: this node acquires a token, the token expires, and another miner
+// then acquires the token (which, per acquireToken, deletes the expired token
+// and writes a fresh one). When the original — now stale — caller finally runs
+// etcdResetWork, the stored token no longer matches, so the reset is rejected
+// with ErrInvalidToken and the work value the new holder set is preserved.
+func TestEtcdResetWork_ExpiredThenSuperseded(t *testing.T) {
+	ma := newTestEtcdAdmin(t)
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+
+	// 1. This node acquires a short-lived token.
+	staleToken, err := ma.acquireToken(ctx, big.NewInt(1001), 1)
+	if err != nil {
+		t.Fatalf("acquireToken failed: %v", err)
+	}
+
+	oldWork := marshalWork(t, 1000, "0x1111111111111111111111111111111111111111111111111111111111111111")
+	if _, err := ma.etcdPut(wemixWorkKey, oldWork); err != nil {
+		t.Fatalf("seed work failed: %v", err)
+	}
+
+	// 2. The token expires.
+	time.Sleep(2200 * time.Millisecond) // > TTL(1s) plus a full-second margin for Unix() truncation
+	if staleToken.ttl() >= 0 {
+		t.Fatalf("token should be logically expired, ttl=%d", staleToken.ttl())
+	}
+
+	// 3. Another miner acquires the token. acquireToken deletes the expired
+	//    token and writes a fresh one; the stored value now differs from
+	//    staleToken. Simulate that miner also advancing the work value.
+	newHolder, err := ma.acquireToken(ctx, big.NewInt(1002), MiningTokenTTL)
+	if err != nil {
+		t.Fatalf("second acquireToken failed: %v", err)
+	}
+	newHolderWork := marshalWork(t, 1001, "0x3333333333333333333333333333333333333333333333333333333333333333")
+	if err := ma.etcdResetWork(newHolder, newHolderWork); err != nil {
+		t.Fatalf("new holder should be able to reset work: %v", err)
+	}
+
+	// 4. The original, now-stale caller tries to reset work with its expired
+	//    token. It must be rejected, leaving the new holder's work intact.
+	staleWork := marshalWork(t, 1001, "0x2222222222222222222222222222222222222222222222222222222222222222")
+	if err := ma.etcdResetWork(staleToken, staleWork); err != ErrInvalidToken {
+		t.Fatalf("stale caller must be rejected with ErrInvalidToken, got %v", err)
+	}
+	if got := mustGetWork(t, ma); got != newHolderWork {
+		t.Fatalf("stale caller overwrote work: want %q, got %q", newHolderWork, got)
+	}
+}
+
+// TestEtcdResetWork_NotReady verifies the guard when etcd is not running.
+func TestEtcdResetWork_NotReady(t *testing.T) {
+	ma := &wemixAdmin{} // no etcd
+	if err := ma.etcdResetWork(&WemixToken{}, "x"); err != ErrNotRunning {
+		t.Fatalf("expected ErrNotRunning, got %v", err)
+	}
+}

--- a/wemix/etcdutil.go
+++ b/wemix/etcdutil.go
@@ -622,6 +622,34 @@ func (ma *wemixAdmin) etcdGet(key string) (string, error) {
 	}
 }
 
+// resets work only while the given token is still held
+func (ma *wemixAdmin) etcdResetWork(token *WemixToken, newWork string) error {
+	if !ma.etcdIsReady() {
+		return ErrNotRunning
+	}
+	lockValue, err := json.Marshal(token)
+	if err != nil {
+		return err
+	}
+	ctx, cancel := context.WithTimeout(context.Background(),
+		ma.etcd.Server.Cfg.ReqTimeout())
+	defer cancel()
+	txresp, err := ma.etcdCli.Txn(ctx).If(
+		clientv3.Compare(clientv3.Value(wemixTokenKey), "=", string(lockValue)),
+	).Then(
+		clientv3.OpPut(wemixWorkKey, newWork),
+	).Else(
+		clientv3.OpGet(wemixTokenKey),
+	).Commit()
+	if err != nil {
+		return err
+	}
+	if !txresp.Succeeded {
+		return ErrInvalidToken
+	}
+	return nil
+}
+
 // compare & swap, do put only if previous value matches
 func (ma *wemixAdmin) etcdPut2(key, value, prev string) error {
 	if !ma.etcdIsReady() {

--- a/wemix/sync.go
+++ b/wemix/sync.go
@@ -31,7 +31,7 @@ type coinbaseEnodeEntry struct {
 const (
 	wemixWorkKey      = "work"
 	wemixTokenKey     = "token"
-	MiningTokenTTL    = 10 // seconds
+	MiningTokenTTL    = 10 // seconds; must be >= 2 to ensure the syncCheck peer collection timeout (MiningTokenTTL/2) is > 0.
 	SyncIdleThreshold = 30 // seconds
 )
 
@@ -338,8 +338,11 @@ func syncCheck() error {
 	}
 
 	// collects mining peers' latest blocks
+	// getMiners timeout must be shorter than MiningTokenTTL to ensure etcdPut and subsequent operations
+	// complete while the token is still held. if the token expires first, another node may advance
+	// work before etcdPut, causing a stale overwrite. MiningTokenTTL/2 leaves headroom for those operations.
 	nodes := admin.getNodes()
-	states := getMiners("", 5000)
+	states := getMiners("", MiningTokenTTL/2)
 	// The original guard `len(nodes)==0 && len(nodes)!=len(states)` was a dead
 	// branch in any healthy environment (nodes>=5). Recovered intent: if the
 	// governance cache is empty we cannot reason about quorum, so abort. The

--- a/wemix/sync.go
+++ b/wemix/sync.go
@@ -439,10 +439,12 @@ func syncCheck() error {
 		Height: consensusHeight.Int64(),
 		Hash:   consensusHash,
 	}
+	// reset work only if the token is still held to prevent a stale overwrite
 	if newWorkData, err := json.Marshal(newWork); err != nil {
 		panic("failed to marshal work data")
-	} else {
-		admin.etcdPut(wemixWorkKey, string(newWorkData))
+	} else if err = admin.etcdResetWork(token, string(newWorkData)); err != nil {
+		log.Error("sync check: token expired or superseded, aborting work reset", "error", err)
+		return err
 	}
 	log.Error("sync check: found consensus block, setting work", "height", consensusHeight, "hash", consensusHash, "error", err)
 	return err

--- a/wemix/sync.go
+++ b/wemix/sync.go
@@ -439,7 +439,9 @@ func syncCheck() error {
 		Height: consensusHeight.Int64(),
 		Hash:   consensusHash,
 	}
-	// reset work only if the token is still held to prevent a stale overwrite
+	// reset work only if the token is still held to prevent a stale overwrite.
+	// WARNING: do not call renew() between acquire and this call: renew updates Till,
+	// causing token to diverge from the value stored in etcd and failing the CAS.
 	if newWorkData, err := json.Marshal(newWork); err != nil {
 		panic("failed to marshal work data")
 	} else if err = admin.etcdResetWork(token, string(newWorkData)); err != nil {


### PR DESCRIPTION
## Overview
Fix a synchronization bug where a delayed validator overwrites the latest consensus state with a stale value during a sync check, halting block production.

## Problem
The peer collection timeout in `syncCheck` exceeded the `MiningTokenTTL`. This allowed the mining token to expire mid-collection, resulting in a stale overwrite that reverted the advanced consensus state.

## Solution
Clamp the peer collection timeout to ensure all operations complete before token expiration, and atomically verify that the local node still holds the matching mining token before writing to etcd.

## Changes
- Introduce `etcdResetWork` in `wemix/etcdutil.go` to perform token-verified conditional writes via etcd transactions.
- Replace the plain `etcdPut` in `sync.go` with `etcdResetWork` to guard the work-key reset.
- Clamp the `getMiners` timeout in `syncCheck` to `MiningTokenTTL/2` (5 seconds).