### PR TITLE
chore: sync v0.10.14 version 

### DIFF
--- a/params/version.go
+++ b/params/version.go
@@ -23,7 +23,7 @@ import (
 const (
 	VersionMajor = 0        // Major version component of the current release
 	VersionMinor = 10       // Minor version component of the current release
-	VersionPatch = 13       // Patch version component of the current release
+	VersionPatch = 14       // Patch version component of the current release
 	VersionMeta  = "stable" // Version metadata to append to the version string
 )
 


### PR DESCRIPTION
## Summary
After merging release/v0.10.14 into master, sync the version bump — present only in the release branch — into dev.

## Changes
- params/version.go: bump version from v0.10.13 to v0.10.14