### PR TITLE
fix: correct block timestamp lower bound logic to use parent time

### DIFF
--- a/miner/worker.go
+++ b/miner/worker.go
@@ -1555,14 +1555,14 @@ func (w *worker) timeIt(blockInterval int64) (timestamp uint64, till time.Time) 
 		offset = 1
 	}
 	timestamp = uint64(nowInSeconds)
-	if timestamp < parent.Number().Uint64() {
-		timestamp = parent.Number().Uint64()
+	if timestamp < parent.Time() {
+		timestamp = parent.Time()
 	}
 	switch offset {
 	case -1: // behind, i.e. too few blocks so far, need to make more
 		tms := nowInMilliSeconds + params.BlockMinBuildTime
 		if tms/1000 <= int64(parent.Time()) {
-			// make sure that no more than 2 blocks have the same timestamp
+			// Delay block completion until the next second boundary to reduce consecutive same-timestamp blocks.
 			tms = (nowInSeconds + 1) * 1000
 		}
 		till = time.Unix(tms/1e3, (tms%1e3)*1e6)

--- a/miner/worker_test.go
+++ b/miner/worker_test.go
@@ -688,3 +688,40 @@ func testGetSealingWork(t *testing.T, chainConfig *params.ChainConfig, engine co
 		}
 	}
 }
+
+func TestTimeItTimestampLowerBound(t *testing.T) {
+	db := rawdb.NewMemoryDatabase()
+	engine := ethash.NewFaker()
+	defer engine.Close()
+
+	w, b := newTestWorker(t, ethashChainConfig, engine, db, 0)
+	defer w.close()
+
+	// case 1: normal clock — insert a block at current time, then verify timestamp follows nowInSeconds
+	blocks, _ := core.GenerateChain(ethashChainConfig, b.chain.Genesis(), engine, db, 1, func(i int, gen *core.BlockGen) {
+		// makeHeader sets header.Time = parent.Time() + 10 by default; subtract that base and an extra 5s
+		// to set the block timestamp slightly in the past, ensuring timestamp > parent.Time().
+		gen.OffsetTime(time.Now().Unix() - int64(b.chain.Genesis().Time()) - 10 - 5)
+	})
+	if _, err := b.chain.InsertChain(blocks); err != nil {
+		t.Fatalf("failed to insert block: %v", err)
+	}
+
+	parent := w.chain.CurrentBlock()
+	if timestamp, _ := w.timeIt(1000); timestamp <= parent.Time() {
+		t.Errorf("normal clock: timestamp %d should be greater than parent.Time %d", timestamp, parent.Time())
+	}
+
+	// case 2: parent timestamp in the future (simulates clock drift) — timestamp must be floored to parent.Time
+	futureBlocks, _ := core.GenerateChain(ethashChainConfig, blocks[0], engine, db, 1, func(i int, gen *core.BlockGen) {
+		gen.OffsetTime(3600)
+	})
+	if _, err := b.chain.InsertChain(futureBlocks); err != nil {
+		t.Fatalf("failed to insert future block: %v", err)
+	}
+
+	parent = w.chain.CurrentBlock()
+	if timestamp, _ := w.timeIt(1000); timestamp != parent.Time() {
+		t.Errorf("future parent: timestamp %d should be floored to parent.Time %d", timestamp, parent.Time())
+	}
+}


### PR DESCRIPTION
## Overview
Correct the block timestamp lower bound logic in `worker.timeIt` to use parent time instead of parent block number.

## Problem
In SPoA mode, the block timestamp lower bound check in `worker.timeIt` compared `timestamp` against `parent.Number()` instead of `parent.Time()`. Since Unix timestamps are numerically far greater than block numbers under normal conditions, the lower bound check was effectively dead code and provided no protection against timestamp regression.

## Solution
Updated the lower bound check to use the parent block's timestamp, ensuring the block header timestamp does not regress below it.

## Changes
- Updated the timestamp lower bound comparison from `parent.Number()` to `parent.Time()` in `miner/worker.go`.