### PR TITLE
fix: resolve shadowing panic in deploy-governance

### DIFF
--- a/cmd/geth/governancedeploy.go
+++ b/cmd/geth/governancedeploy.go
@@ -76,7 +76,8 @@ func deployGovernanceContracts(ctx *cli.Context) error {
 	switch len(args) {
 	case 3:
 		configFile, accountFile = args[0], args[1]
-		lockAmount, ok := new(big.Int).SetString(args[2], 10)
+		var ok bool
+		lockAmount, ok = new(big.Int).SetString(args[2], 10)
 		if !ok || lockAmount.Sign() <= 0 {
 			return errInvalidArguments
 		}


### PR DESCRIPTION
## Overview

Fixed a bug in `deployGovernanceContracts()` where `:=` in the 3-argument parsing block shadowed the outer `lockAmount *big.Int`, leaving it `nil` and causing a nil pointer dereference panic at `lockAmount.Cmp()` in `deployGovernance()`.

## Changes

- `cmd/geth/governancedeploy.go`: Replaced `lockAmount, ok := ...` with `var ok bool` declaration followed by `lockAmount, ok = ...`