### PR TITLE
fix: skip token acquisition when worker stopped

### DIFF
--- a/miner/worker.go
+++ b/miner/worker.go
@@ -1603,13 +1603,19 @@ func (w *worker) commitWork(interrupt *int32, noempty bool, timestamp int64) {
 		return
 	}
 	if !wemixminer.IsPoW() {
+		// Skip token acquisition while the worker is stopped (e.g. during sync).
+		// commitEx's block build & ReleaseMiningToken are gated by isRunning(),
+		// so acquiring here would leak the cluster-shared token until its Till expires.
+		if !w.isRunning() {
+			w.refreshPending(true)
+			return
+		}
+
 		ok, err := wemixminer.AcquireMiningToken(height, parent.Hash())
 		if ok {
 			log.Debug("Mining Token, successful", "height", height, "parent-hash", parent.Hash())
 		} else {
 			log.Debug("Mining Token, failure", "height", height, "parent-hash", parent.Hash(), "error", err)
-		}
-		if !ok {
 			w.refreshPending(true)
 			return
 		}

--- a/miner/worker_test.go
+++ b/miner/worker_test.go
@@ -725,3 +725,40 @@ func TestTimeItTimestampLowerBound(t *testing.T) {
 		t.Errorf("future parent: timestamp %d should be floored to parent.Time %d", timestamp, parent.Time())
 	}
 }
+
+func TestSkipMiningTokenAcquisitionWhenWorkerStopped(t *testing.T) {
+	oldConsensus := params.ConsensusMethod
+	params.ConsensusMethod = params.ConsensusPoA
+	defer func() { params.ConsensusMethod = oldConsensus }()
+
+	cfg := new(params.ChainConfig)
+	*cfg = *params.TestChainConfig
+	cfg.CroissantBlock = nil
+
+	w, _ := newTestWorker(t, cfg, clique.New(cliqueChainConfig.Clique, rawdb.NewMemoryDatabase()), rawdb.NewMemoryDatabase(), 0)
+	defer w.close()
+
+	var acquired int32
+	oldAcquireFunc := wemixminer.AcquireMiningTokenFunc
+	wemixminer.AcquireMiningTokenFunc = func(height *big.Int, parentHash common.Hash) (bool, error) {
+		atomic.AddInt32(&acquired, 1)
+		return true, nil
+	}
+	defer func() { wemixminer.AcquireMiningTokenFunc = oldAcquireFunc }()
+
+	// Case 1: When worker is stopped (!w.isRunning()), commitWork should skip token acquisition
+	w.stop()
+	w.commitWork(nil, false, time.Now().Unix())
+
+	if atomic.LoadInt32(&acquired) != 0 {
+		t.Errorf("AcquireMiningTokenFunc should NOT be called when worker is stopped, got count: %d", acquired)
+	}
+
+	// Case 2: When worker is running (w.isRunning()), commitWork should attempt token acquisition
+	w.start()
+	w.commitWork(nil, false, time.Now().Unix())
+
+	if atomic.LoadInt32(&acquired) != 1 {
+		t.Errorf("AcquireMiningTokenFunc SHOULD be called when worker is running, got count: %d", acquired)
+	}
+}


### PR DESCRIPTION
## Overview
Prevent cluster-shared mining token leak and chain stall during block synchronization.

## Problem
During block synchronization or when the worker is not running (`isRunning() == false`), `commitWork()` still attempted to acquire mining tokens. Because block assembly and `ReleaseMiningToken()` inside `commitEx()` are gated by `isRunning()`, acquired tokens were never released, causing cluster-shared etcd token leaks and chain stalls until token expiration.

## Solution
Guard token acquisition with an `isRunning()` check in `commitWork()` so stopped workers bypass token requests.

## Changes
- Add `w.isRunning()` guard check prior to `AcquireMiningToken()` in `miner/worker.go`