### PR TITLE
fix: prevent divide-by-zero panic in etcdAutoJoin when no peers found

### DIFF
--- a/wemix/etcdutil.go
+++ b/wemix/etcdutil.go
@@ -495,6 +495,13 @@ func (ma *wemixAdmin) etcdAutoJoin() error {
 		}
 	}
 
+	// gap is set only when getMiners returns a non-empty list and self is found.
+	// If gap == 0, there are no peers to coordinate with, so there is nothing to schedule.
+	// Without this guard, tt = sz * gap = 0 and ct/tt panics with integer divide-by-zero.
+	if gap == 0 {
+		return ErrNotFound
+	}
+
 	// schedule it
 	tt := sz * gap
 	ct := time.Now().Unix()


### PR DESCRIPTION
## Summary
Prevent an integer divide-by-zero panic in `etcdAutoJoin` that crashes the entire process when no mining peers are found.

## Problem
`etcdAutoJoin` initializes `sz` and `gap` to 0. These are only assigned inside the `if len(states) > 0` block. If `getMiners("", 0)` returns an empty slice (e.g., network isolation, no peer connections on startup), the block is skipped and both variables remain 0.

The subsequent schedule calculation computes `tt = sz * gap = 0`, then `ct/tt` triggers an integer divide-by-zero panic. Because `etcdAutoJoin` runs in a goroutine launched from `EtcdStart` with no `recover`, the panic crashes the entire node process.

## Changes
- `wemix/etcdutil.go`: add an early return when `gap == 0` before the schedule calculation. `gap` is only set inside the `getMiners` block, so `gap == 0` reliably indicates no peers were found.