### PR TITLE
fix: enforce RLP-encoded block size limit (EIP-7934)

### DIFF
--- a/core/block_validator.go
+++ b/core/block_validator.go
@@ -51,6 +51,10 @@ func NewBlockValidator(config *params.ChainConfig, blockchain *BlockChain, engin
 // header's transaction and uncle roots. The headers are assumed to be already
 // validated at this point.
 func (v *BlockValidator) ValidateBody(block *types.Block) error {
+	// Reject blocks whose RLP-encoded size exceeds the cap (EIP-7934).
+	if uint64(block.Size()) > params.MaxBlockSize {
+		return ErrBlockOversized
+	}
 	// Check whether the block's known, and if not, that it's linkable
 	if v.bc.HasBlockAndState(block.Hash(), block.NumberU64()) {
 		return ErrKnownBlock

--- a/core/block_validator_test.go
+++ b/core/block_validator_test.go
@@ -18,6 +18,7 @@ package core
 
 import (
 	"encoding/json"
+	"errors"
 	"math/big"
 	"runtime"
 	"testing"
@@ -400,5 +401,60 @@ func TestCalcGasLimit(t *testing.T) {
 		if have, want := CalcGasLimit(tc.pGasLimit, tc.pGasLimit), tc.pGasLimit; have != want {
 			t.Errorf("test %d: have %d want %d", i, have, want)
 		}
+	}
+}
+
+func TestValidateBodyBlockOversized(t *testing.T) {
+	testdb := rawdb.NewMemoryDatabase()
+	gspec := &Genesis{Config: params.TestChainConfig}
+	genesis := gspec.MustCommit(testdb)
+	chain, err := NewBlockChain(testdb, nil, params.TestChainConfig, ethash.NewFaker(), vm.Config{}, nil, nil)
+	if err != nil {
+		t.Fatalf("failed to create blockchain: %v", err)
+	}
+	defer chain.Stop()
+
+	validator := NewBlockValidator(params.TestChainConfig, chain, ethash.NewFaker())
+
+	// A normal block (<= MaxBlockSize) must not be rejected as oversized.
+	if err := validator.ValidateBody(genesis); errors.Is(err, ErrBlockOversized) {
+		t.Fatalf("expected normal block not to return ErrBlockOversized, got %v", err)
+	}
+
+	// Accumulate 200KB txs until the block's RLP size exceeds MaxBlockSize.
+	payload200KB := make([]byte, 200*1024)
+	var txs []*types.Transaction
+	var totalSize uint64
+
+	for nonce := uint64(0); totalSize <= params.MaxBlockSize; nonce++ {
+		tx := types.NewTx(&types.LegacyTx{
+			Nonce:    nonce,
+			To:       &common.Address{},
+			Value:    big.NewInt(0),
+			Gas:      500_000,
+			GasPrice: big.NewInt(1),
+			Data:     payload200KB,
+		})
+		txs = append(txs, tx)
+		totalSize += uint64(tx.Size())
+	}
+	// Each tx stays under the per-tx cap, so the block is oversized on total
+	// size, not on any single transaction.
+	if uint64(txs[0].Size()) > params.MaxTransactionSize {
+		t.Fatalf("tx size (%v) exceeds MaxTransactionSize (%d)", txs[0].Size(), params.MaxTransactionSize)
+	}
+
+	oversizedBlock := types.NewBlockWithHeader(&types.Header{
+		Number: big.NewInt(1),
+		Time:   1001,
+	}).WithBody(txs, nil)
+
+	if uint64(oversizedBlock.Size()) <= params.MaxBlockSize {
+		t.Fatalf("expected oversized block size > %d, got %v", params.MaxBlockSize, oversizedBlock.Size())
+	}
+
+	err = validator.ValidateBody(oversizedBlock)
+	if !errors.Is(err, ErrBlockOversized) {
+		t.Fatalf("expected ErrBlockOversized, got %v", err)
 	}
 }

--- a/core/error.go
+++ b/core/error.go
@@ -32,6 +32,10 @@ var (
 	// ErrNoGenesis is returned when there is no Genesis Block.
 	ErrNoGenesis = errors.New("genesis not found in chain")
 
+	// ErrBlockOversized is returned if the size of the RLP-encoded block
+	// exceeds the cap established by EIP-7934.
+	ErrBlockOversized = errors.New("block RLP-encoded size exceeds maximum")
+
 	errSideChainReceipts = errors.New("side blocks can't be accepted as ancient chain data")
 )
 

--- a/eth/protocols/eth/protocol.go
+++ b/eth/protocols/eth/protocol.go
@@ -48,7 +48,7 @@ var ProtocolVersions = []uint{ETH68, ETH66, ETH65}
 var protocolLengths = map[uint]uint64{ETH66: 23, ETH65: 23, ETH68: 17}
 
 // maxMessageSize is the maximum cap on the size of a protocol message.
-const maxMessageSize = 100 * 1024 * 1024
+const maxMessageSize = 10 * 1024 * 1024
 
 const (
 	// Protocol messages in eth/64

--- a/miner/worker.go
+++ b/miner/worker.go
@@ -99,6 +99,7 @@ type environment struct {
 	txs      []*types.Transaction
 	receipts []*types.Receipt
 	uncles   map[common.Hash]*types.Header
+	size     uint64 // size of the block we are building
 
 	// wemix parameters
 	till                 *time.Time // until when to block generation holds
@@ -120,6 +121,7 @@ func (env *environment) copy() *environment {
 		header:    types.CopyHeader(env.header),
 		receipts:  copyReceipts(env.receipts),
 		till:      env.till,
+		size:      env.size,
 	}
 	if env.gasPool != nil {
 		gasPool := *env.gasPool
@@ -134,6 +136,15 @@ func (env *environment) copy() *environment {
 		cpy.uncles[hash] = uncle
 	}
 	return cpy
+}
+
+// maxBlockSizeBufferZone is subtracted from params.MaxBlockSize when producing
+// blocks, to stay below the cap after auxiliary data is added into the block.
+const maxBlockSizeBufferZone = 1_000_000
+
+// txFitsSize reports whether the transaction fits into the block size limit.
+func (env *environment) txFitsSize(tx *types.Transaction) bool {
+	return env.size+uint64(tx.Size()) < params.MaxBlockSize-maxBlockSizeBufferZone
 }
 
 // unclelist returns the contained uncles as the list format.
@@ -850,6 +861,7 @@ func (w *worker) makeEnv(parent *types.Block, header *types.Header, coinbase com
 		family:    mapset.NewSet(),
 		header:    header,
 		uncles:    make(map[common.Hash]*types.Header),
+		size:      uint64(header.Size()),
 	}
 	// when 08 is processed ancestors contain 07 (quick block)
 	for _, ancestor := range w.chain.GetBlocksFromHash(parent.Hash(), 7) {
@@ -915,6 +927,7 @@ func (w *worker) commitTransaction(env *environment, tx *types.Transaction) ([]*
 	}
 	env.txs = append(env.txs, tx)
 	env.receipts = append(env.receipts, receipt)
+	env.size += uint64(tx.Size())
 
 	return receipt.Logs, nil
 }
@@ -956,6 +969,10 @@ func (w *worker) commitTransactions(env *environment, txs *types.TransactionsByP
 		// Retrieve the next transaction and abort if all done
 		tx := txs.Peek()
 		if tx == nil {
+			break
+		}
+		// Break if the transaction would exceed the block size limit.
+		if !env.txFitsSize(tx) {
 			break
 		}
 		// Break if it has enough transactions
@@ -1085,6 +1102,10 @@ func (w *worker) commitTransactionsSimple(env *environment, txs *TxOrderer, inte
 		// Retrieve the next transaction and abort if all done
 		tx := txs.Peek()
 		if tx == nil {
+			break
+		}
+		// Break if the transaction would exceed the block size limit.
+		if !env.txFitsSize(tx) {
 			break
 		}
 		// Break if it took too long

--- a/miner/worker_test.go
+++ b/miner/worker_test.go
@@ -26,6 +26,7 @@ import (
 
 	"github.com/ethereum/go-ethereum/accounts"
 	"github.com/ethereum/go-ethereum/common"
+	"github.com/ethereum/go-ethereum/common/math"
 	"github.com/ethereum/go-ethereum/consensus"
 	"github.com/ethereum/go-ethereum/consensus/clique"
 	"github.com/ethereum/go-ethereum/consensus/ethash"
@@ -760,5 +761,82 @@ func TestSkipMiningTokenAcquisitionWhenWorkerStopped(t *testing.T) {
 
 	if atomic.LoadInt32(&acquired) != 1 {
 		t.Errorf("AcquireMiningTokenFunc SHOULD be called when worker is running, got count: %d", acquired)
+	}
+}
+
+func TestCommitTransactionsBlockSizeLimit(t *testing.T) {
+	testCommitBlockSizeLimit(t, func(w *worker, env *environment, pending map[common.Address]types.Transactions) {
+		txs := types.NewTransactionsByPriceAndNonce(env.signer, pending, env.header.BaseFee)
+		// committedTxs may be nil: commitTransactions nil-checks before writing.
+		if err := w.commitTransactions(env, txs, nil, nil, nil); err != nil {
+			t.Fatalf("commitTransactions failed: %v", err)
+		}
+	})
+}
+
+func TestCommitTransactionsSimpleBlockSizeLimit(t *testing.T) {
+	testCommitBlockSizeLimit(t, func(w *worker, env *environment, pending map[common.Address]types.Transactions) {
+		// committedTxs must be non-nil: MarkCommitted writes to it unconditionally.
+		txs := NewTxOrderer(pending, make(map[common.Hash]*types.Transaction))
+		if err := w.commitTransactionsSimple(env, txs, nil, nil); err != nil {
+			t.Fatalf("commitTransactionsSimple failed: %v", err)
+		}
+	})
+}
+
+// testCommitBlockSizeLimit feeds an oversized set of pending transactions into the
+// given commit loop and asserts packing stops before the block exceeds the size limit.
+func testCommitBlockSizeLimit(t *testing.T, commit func(w *worker, env *environment, pending map[common.Address]types.Transactions)) {
+	w, b := newTestWorker(t, ethashChainConfig, ethash.NewFaker(), rawdb.NewMemoryDatabase(), 0)
+	defer w.close()
+
+	var (
+		limit  = uint64(params.MaxBlockSize - maxBlockSizeBufferZone)
+		key, _ = crypto.GenerateKey()
+		addr   = crypto.PubkeyToAddress(key.PublicKey)
+	)
+
+	// Gas limit set high enough that packing stops on block size, not gas.
+	header := &types.Header{
+		Number:     big.NewInt(1),
+		Difficulty: big.NewInt(1),
+		GasLimit:   105_000_000,
+		BaseFee:    big.NewInt(params.InitialBaseFee),
+		Fees:       new(big.Int),
+		Time:       1000,
+	}
+	env, err := w.makeEnv(b.chain.CurrentBlock(), header, testBankAddress)
+	if err != nil {
+		t.Fatalf("failed to make env: %v", err)
+	}
+	env.state.SetBalance(addr, math.MaxBig256)
+
+	// Emit txs until their total exceeds the limit so packing stops on size, not
+	// tx count; nonces < 128 keep every tx's RLP size identical.
+	payload200KB := make([]byte, 200*1024)
+	pending := make(map[common.Address]types.Transactions)
+	for size := uint64(header.Size()); size <= limit; {
+		tx := types.MustSignNewTx(key, env.signer, &types.LegacyTx{
+			Nonce:    uint64(len(pending[addr])),
+			To:       &testUserAddress,
+			Value:    big.NewInt(1),
+			Gas:      5_000_000,
+			GasPrice: big.NewInt(10 * params.InitialBaseFee),
+			Data:     payload200KB,
+		})
+		pending[addr] = append(pending[addr], tx)
+		size += uint64(tx.Size())
+	}
+	txSize := uint64(pending[addr][0].Size())
+
+	commit(w, env, pending)
+
+	// The block stays under the limit, and one more tx would exceed it: size (not
+	// gas or tx exhaustion) stopped packing.
+	if env.size >= limit {
+		t.Fatalf("packed block size (%d) reached or exceeded the limit (%d)", env.size, limit)
+	}
+	if env.size+txSize < limit {
+		t.Fatalf("packing stopped early, another tx would still fit (size=%d, txSize=%d, limit=%d)", env.size, txSize, limit)
 	}
 }

--- a/params/protocol_params.go
+++ b/params/protocol_params.go
@@ -126,6 +126,8 @@ const (
 	MaxCodeSize        = 253952 // Maximum bytecode to permit for a contract
 	MaxTransactionSize = 262144 // Maximum transaction size
 
+	MaxBlockSize = 8_388_608 // Maximum size of an RLP-encoded block (EIP-7934)
+
 	// Precompiled contract gas prices
 
 	EcrecoverGas        uint64 = 3000 // Elliptic curve sender recovery gas price


### PR DESCRIPTION
## Overview
Introduce an RLP-encoded block size cap (EIP-7934) so that oversized blocks are never produced, closing a chain-halt vector. This ports the upstream go-ethereum implementation (ethereum/go-ethereum#31990).

## Problem
Block production had no cap on a block's RLP-encoded size. A miner could build a block larger than the network's transport limit (RLPx's 16 MiB frame limit) and import it into its own local canonical chain. Such a block cannot be propagated to peers, so the rest of the network cannot follow the chain: synchronization stalls and block production halts.

## Solution
Adopt the EIP-7934 8 MiB RLP-encoded block size cap and enforce it across the block lifecycle:
- Mining: stop packing transactions before the block reaches the cap, keeping a buffer for auxiliary data, so oversized blocks are never produced.
- Validation: make the cap a body-validity rule, rejecting any block whose RLP-encoded size exceeds it.
- Networking: lower the eth protocol message cap to 10 MiB to match the new block size cap, since no valid block can approach the former 100 MiB limit.

## Changes
- Add `MaxBlockSize` (8 MiB) in `params/protocol_params.go`.
- Track block size in `environment` and add `maxBlockSizeBufferZone` (1 MB) with `txFitsSize`; break out of `commitTransactions` and `commitTransactionsSimple` before the block exceeds the cap in `miner/worker.go`.
- Reject oversized blocks in `BlockValidator.ValidateBody` with the new `ErrBlockOversized` in `core/block_validator.go` and `core/error.go`.
- Lower `maxMessageSize` from 100 MiB to 10 MiB in `eth/protocols/eth/protocol.go`.

## References
- ethereum/go-ethereum#31990
- [EIP-7934: RLP Execution Block Size Limit](https://eips.ethereum.org/EIPS/eip-7934)